### PR TITLE
fix: pin Python versions and fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist -i 3.10 3.11 3.12 3.13
           manylinux: auto
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- `macos-13` → `macos-latest`: 廃止ランナーの置き換え
- `--find-interpreter` → `-i 3.10 3.11 3.12 3.13`: Python 3.14検出によるPyO3ビルドエラーの回避
- `fail-fast: false`: 1プラットフォーム失敗時の連鎖キャンセル防止

## 根本原因

1. `macos-13`ランナーがGitHub Actionsで廃止済み
2. `--find-interpreter`がランナー上のPython 3.14を検出し、PyO3 0.23.5（最大3.13）でビルド不可
3. aarch64 Dockerコンテナ内でPython自動検出が失敗

## Test plan

- [ ] v0.1.0リリース再作成で全プラットフォームのwheel buildが成功
- [ ] PyPIへのpublishが成功