### PR TITLE
feat: DATE decomposition + retrospective attribution mode (arXiv:2602.00836)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [Unreleased]
+
+### Added
+
+- DATE decomposition (`ci.decompose()`): decomposes pointwise causal effects
+  into spot, persistent, and trend components via OLS projection on the
+  MCMC posterior. Pure Python, no Rust changes.
+  Reference: Schaffe-Odeleye et al. (2026), arXiv:2602.00836.
+- Decomposition plot panel: `ci.plot(metrics=[..., "decomposition"])` adds a
+  fourth panel showing the three components with credible intervals.
+- `DateDecomposition` and `EffectComponent` exported from `causal_impact`.
+- Retrospective attribution mode (`mode="retrospective"`): treatment indicator
+  columns (spot, persistent, trend) are added as covariates and the model is fit
+  on the entire time series. Effects are extracted from beta posteriors.
+  Reference: Schaffe-Odeleye et al. (2026), arXiv:2602.00836.
+- "Beyond R" documentation section covering all Python-only extensions
+  (DATE decomposition, retrospective mode, placebo test, conformal inference,
+  DTW control selection).
+- `docs/theory.md`: mathematical background for DATE decomposition.
+- MathJax support in mkdocs for LaTeX rendering.
+
 ## [1.3.1] - 2026-03-23
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "causal_impact_core"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "numpy",
  "pyo3",

--- a/README.md
+++ b/README.md
@@ -202,9 +202,27 @@ Evidence per implementation (all verified from source code, not documentation cl
 | Seasonal component (`nseasons`, `season_duration`) | Matching | State-space model matching R bsts `AddSeasonal()` (±1% CI parity) |
 | Dynamic regression | Supported | Time-varying coefficients via random-walk FFBS; `dynamic_regression=True` |
 | Local linear trend | Supported | Opt in with `state_model="local_linear_trend"` |
+| DATE decomposition | Extended | Decomposes effects into spot/persistent/trend (arXiv:2602.00836) |
+| Retrospective mode | Extended | Treatment indicators as covariates; effects from beta posteriors (arXiv:2602.00836) |
+| Placebo test | Extended | Null distribution from pre-period splits |
+| Conformal inference | Extended | Distribution-free prediction intervals |
+| DTW control selection | Extended | Automatic covariate selection via Dynamic Time Warping |
 
 Matching = CI-enforced numerical equivalence with R bsts (±1% or tighter).
 Supported = Feature implemented, no R parity fixture yet.
+Extended = Python-only feature with no R equivalent.
+
+### Beyond R: Python-Only Extensions
+
+Features that go beyond R's CausalImpact. These have no R equivalent.
+
+| Feature | Method | What it does | Reference |
+|---|---|---|---|
+| DATE decomposition | `ci.decompose()` | Decomposes causal effect into spot, persistent, and trend | Schaffe-Odeleye et al. (2026), arXiv:2602.00836 |
+| Retrospective mode | `mode="retrospective"` | Treatment indicators as covariates; effects extracted from beta posteriors | Schaffe-Odeleye et al. (2026), arXiv:2602.00836 |
+| Placebo test | `ci.run_placebo_test()` | Validates effect against null distribution from pre-period splits | |
+| Conformal inference | `ci.run_conformal_analysis()` | Distribution-free prediction intervals | Vovk et al. (2005) |
+| DTW control selection | `select_controls()` | Automatic covariate selection via Dynamic Time Warping | Sakoe & Chiba (1978) |
 
 ## API
 
@@ -233,6 +251,7 @@ Supported = Feature implemented, no R parity fixture yet.
 | `season_duration` | `None` | Optional duration of each seasonal block; defaults to `1` when `nseasons` is set |
 | `dynamic_regression` | `False` | Enable time-varying regression coefficients (random-walk beta) |
 | `state_model` | `"local_level"` | `"local_level"` or `"local_linear_trend"` |
+| `mode` | `"forward"` | `"forward"` (counterfactual prediction) or `"retrospective"` (treatment indicators as covariates) |
 
 #### Methods and Properties
 
@@ -244,6 +263,9 @@ Supported = Feature implemented, no R parity fixture yet.
 | `inferences` | `DataFrame` | Per-timestep actuals, predictions, prediction s.d., and effect intervals |
 | `summary_stats` | `dict` | Aggregate statistics (effect mean, CI, p-value, etc.) |
 | `posterior_inclusion_probs` | `ndarray \| None` | Posterior inclusion probability per covariate |
+| `decompose(alpha=None)` | `DateDecomposition` | DATE decomposition into spot/persistent/trend components |
+| `run_placebo_test(...)` | `PlaceboTestResults` | Placebo test for effect validation |
+| `run_conformal_analysis(...)` | `ConformalResults` | Distribution-free conformal prediction intervals |
 
 ## Benchmark Results
 
@@ -268,6 +290,8 @@ python/causal_impact/
     analysis.py          # CausalAnalysis: effect computation, CI, p-values
     summary.py           # SummaryFormatter: tabular and narrative reports
     plot.py              # Plotter: matplotlib visualization
+    decomposition.py     # DATE decomposition (spot/persistent/trend)
+    retrospective.py     # Retrospective attribution mode
 
 src/ (Rust)
     lib.rs               # PyO3 entry point: run_gibbs_sampler()

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,7 +24,10 @@ ci = CausalImpact(data, pre_period, post_period, model_args=None, alpha=0.05)
 |---|---|---|
 | `summary(output="summary", digits=2)` | `str` | Tabular summary of causal effects. Set `output="report"` for narrative form. |
 | `report()` | `str` | Narrative interpretation of results (shortcut for `summary(output="report")`) |
-| `plot(metrics=None)` | `Figure` | Matplotlib figure with original/pointwise/cumulative panels. Pass a list like `["original", "cumulative"]` to select panels. |
+| `plot(metrics=None)` | `Figure` | Matplotlib figure with original/pointwise/cumulative panels. Pass a list like `["original", "cumulative"]` to select panels. Add `"decomposition"` for the DATE panel. |
+| `decompose(alpha=None)` | `DateDecomposition` | DATE decomposition of pointwise effects into spot/persistent/trend. Call before plotting with `"decomposition"` metric. |
+| `run_placebo_test(n_placebos=None, min_pre_length=3)` | `PlaceboTestResults` | Validates the causal effect against a null distribution from pre-period splits. |
+| `run_conformal_analysis(alpha=None)` | `ConformalResults` | Distribution-free prediction intervals via split conformal inference. |
 
 ### Properties
 
@@ -56,6 +59,7 @@ ci = CausalImpact(data, pre_period, post_period, model_args=opts)
 | `expected_model_size` | `int` | 2 | Expected number of active covariates for spike-and-slab prior |
 | `dynamic_regression` | `bool` | `False` | Enable time-varying regression coefficients |
 | `state_model` | `str` | `"local_level"` | `"local_level"` or `"local_linear_trend"` |
+| `mode` | `str` | `"forward"` | `"forward"` (counterfactual prediction) or `"retrospective"` (treatment indicators as covariates). Retrospective mode adds spot/persistent/trend columns to X and fits on the entire series. Effects are extracted from beta posteriors. |
 | `nseasons` | `int \| None` | `None` | Seasonal cycle count. `nseasons=1` is equivalent to no seasonal component. |
 | `season_duration` | `int \| None` | `None` | Duration of each seasonal block; defaults to 1 when `nseasons` is set. Requires `nseasons` to be set. |
 
@@ -81,3 +85,76 @@ Returned by `ci._results`. A frozen dataclass containing all computed quantities
 | `predictions_sd` | `ndarray` | Posterior standard deviation of the counterfactual prediction |
 | `predictions_lower` | `ndarray` | Lower CI on counterfactual |
 | `predictions_upper` | `ndarray` | Upper CI on counterfactual |
+
+## Beyond R Extensions
+
+### Retrospective Mode
+
+In retrospective mode (`mode="retrospective"`), treatment indicator columns
+(spot, persistent, trend) are added as covariates and the BSTS model is fit on
+the entire time series. Treatment effects are extracted directly from the beta
+posteriors for the treatment columns, rather than from counterfactual predictions.
+
+Key differences from forward mode:
+
+- The model fits on all data (pre + post), not just pre-period
+- Spike-and-slab variable selection is auto-disabled
+- `ci._decomposition` is populated automatically (no need to call `ci.decompose()`)
+- `ci.decompose()` is still available but uses the forward-mode OLS projection
+
+Reference: Schaffe-Odeleye et al. (2026), arXiv:2602.00836.
+
+### `DateDecomposition`
+
+Returned by `ci.decompose()` or auto-populated in retrospective mode.
+A frozen dataclass containing the DATE decomposition results.
+
+Reference: Schaffe-Odeleye et al. (2026), arXiv:2602.00836.
+
+| Field | Type | Description |
+|---|---|---|
+| `spot` | `EffectComponent` | Immediate impulse effect at intervention |
+| `persistent` | `EffectComponent` | Sustained level shift from intervention onward |
+| `trend` | `EffectComponent \| None` | Linearly growing/decaying effect. `None` when `T_post < 3`. |
+| `residual_mean` | `ndarray` | Mean residual trajectory after decomposition |
+| `design_matrix` | `ndarray` | The D matrix used for OLS projection |
+| `alpha` | `float` | Significance level used for credible intervals |
+
+### `EffectComponent`
+
+Each component of the DATE decomposition.
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | `str` | Component name: `"spot"`, `"persistent"`, or `"trend"` |
+| `coefficient` | `float` | Posterior mean of the OLS coefficient |
+| `ci_lower` | `float` | Lower credible interval bound on coefficient |
+| `ci_upper` | `float` | Upper credible interval bound on coefficient |
+| `samples` | `ndarray` | Per-sample trajectories, shape `(n_samples, T_post)` |
+| `coefficients` | `ndarray` | OLS coefficient per sample, shape `(n_samples,)` |
+| `mean` | `ndarray` | Posterior mean trajectory, shape `(T_post,)` |
+| `lower` | `ndarray` | Lower CI on trajectory, shape `(T_post,)` |
+| `upper` | `ndarray` | Upper CI on trajectory, shape `(T_post,)` |
+
+### `PlaceboTestResults`
+
+Returned by `ci.run_placebo_test()`. Validates the effect against a null distribution.
+
+| Field | Type | Description |
+|---|---|---|
+| `p_value` | `float` | Fraction of placebo effects >= real effect |
+| `rank_ratio` | `float` | Conservative p-value estimate |
+| `effect_distribution` | `ndarray` | Absolute average effects from each placebo split |
+| `real_effect` | `float` | Absolute average effect from the real intervention |
+| `n_placebos` | `int` | Number of placebo splits evaluated |
+
+### `ConformalResults`
+
+Returned by `ci.run_conformal_analysis()`. Distribution-free prediction intervals.
+
+| Field | Type | Description |
+|---|---|---|
+| `q_hat` | `float` | Conformal quantile threshold |
+| `lower` | `ndarray` | Lower conformal prediction interval for post-period |
+| `upper` | `ndarray` | Upper conformal prediction interval for post-period |
+| `n_calibration` | `int` | Number of calibration points used |

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -75,3 +75,15 @@ Comparison of features between R CausalImpact (bsts 1.4.1) and this Python imple
 | p_value significance | Match at alpha=0.05 | Passing |
 
 Tests run against R CausalImpact 1.4.1 fixtures on every PR.
+
+## Python-Only Extensions
+
+Features that extend beyond R CausalImpact. No R equivalent exists.
+
+| Feature | Method | Description |
+|---|---|---|
+| DATE decomposition | `ci.decompose()` | Decomposes causal effect into spot/persistent/trend (arXiv:2602.00836) |
+| Retrospective mode | `mode="retrospective"` | Treatment indicators as covariates; effects from beta posteriors (arXiv:2602.00836) |
+| Placebo test | `ci.run_placebo_test()` | Validates effect against null distribution from pre-period splits |
+| Conformal inference | `ci.run_conformal_analysis()` | Distribution-free prediction intervals (Vovk et al., 2005) |
+| DTW control selection | `select_controls()` | Automatic covariate selection via Dynamic Time Warping |

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -437,8 +437,131 @@ print(ci.posterior_inclusion_probs)
 | No Effect (negative control) | 0.0 | -0.55 | [-1.50, 0.48] | 0.118 | No (correct) |
 | Multiple Covariates | 5.0 | 6.53 | [3.64, 9.67] | 0.001 | Yes |
 
-All six examples produce correct results:
+---
+
+## 7. DATE Decomposition (Spot / Persistent / Trend)
+
+Decompose the estimated causal effect into three interpretable components.
+This example uses synthetic data with a known persistent effect of +3 and
+a trend of +0.1 per time step.
+
+Reference: Schaffe-Odeleye et al. (2026), arXiv:2602.00836.
+
+```python
+rng = np.random.default_rng(42)
+
+n_pre, n_post = 100, 30
+n = n_pre + n_post
+x = np.zeros(n)
+x[0] = 100
+for t in range(1, n):
+    x[t] = 0.999 * x[t - 1] + rng.normal(0, 1)
+
+y = 1.2 * x + rng.normal(0, 1, size=n)
+# Inject a persistent shift + trend
+y[n_pre:] += 3.0 + 0.1 * np.arange(n_post)
+
+dates = pd.date_range("2020-01-01", periods=n, freq="D")
+data = pd.DataFrame({"y": y, "x": x}, index=dates)
+pre_period = ["2020-01-01", "2020-04-09"]
+post_period = ["2020-04-10", "2020-05-09"]
+
+ci = CausalImpact(data, pre_period, post_period, model_args={"seed": 42})
+dec = ci.decompose()
+
+print(f"Spot:       {dec.spot.coefficient:+.2f}  [{dec.spot.ci_lower:+.2f}, {dec.spot.ci_upper:+.2f}]")
+print(f"Persistent: {dec.persistent.coefficient:+.2f}  [{dec.persistent.ci_lower:+.2f}, {dec.persistent.ci_upper:+.2f}]")
+if dec.trend is not None:
+    print(f"Trend:      {dec.trend.coefficient:+.2f}  [{dec.trend.ci_lower:+.2f}, {dec.trend.ci_upper:+.2f}]")
+```
+
+### Interpreting the results
+
+| Component | True value | What it means |
+|---|---|---|
+| Spot | 0.0 | No immediate one-time impact |
+| Persistent | 3.0 | Permanent baseline shift |
+| Trend | 0.1 | Effect grows by 0.1 per time step |
+
+### Plotting with decomposition
+
+```python
+fig = ci.plot(metrics=["original", "pointwise", "cumulative", "decomposition"])
+fig.savefig("example_decomposition.png", dpi=150, bbox_inches="tight")
+```
+
+The fourth panel shows the three components with credible intervals.
+
+---
+
+## 8. Retrospective Attribution Mode
+
+In retrospective mode, treatment indicator columns (spot, persistent, trend)
+are added as covariates and the model is fit on the entire time series.
+Treatment effects are extracted directly from the beta posteriors.
+
+This approach avoids the counterfactual prediction step of forward mode and
+instead estimates treatment effects within a single model fit.
+
+```python
+import numpy as np
+import pandas as pd
+from causal_impact import CausalImpact
+
+rng = np.random.default_rng(42)
+
+n_pre, n_post = 200, 50
+n = n_pre + n_post
+y = np.cumsum(rng.normal(0, 0.3, n)) + 50
+y += rng.normal(0, 0.5, n)
+# Inject a persistent level shift of +5 at intervention
+y[n_pre:] += 5.0
+
+dates = pd.date_range("2020-01-01", periods=n, freq="D")
+data = pd.DataFrame({"y": y}, index=dates)
+pre_period = [dates[0], dates[n_pre - 1]]
+post_period = [dates[n_pre], dates[-1]]
+
+ci = CausalImpact(
+    data, pre_period, post_period,
+    model_args={
+        "niter": 2000, "nwarmup": 1000, "seed": 42,
+        "mode": "retrospective",
+        "prior_level_sd": 0.001,
+    },
+)
+
+# Decomposition is auto-populated in retrospective mode
+dec = ci._decomposition
+print(f"Spot:       {dec.spot.coefficient:+.2f}")
+print(f"Persistent: {dec.persistent.coefficient:+.2f}")
+if dec.trend is not None:
+    print(f"Trend:      {dec.trend.coefficient:+.2f}")
+
+# Standard summary and plot still work
+print(ci.summary())
+fig = ci.plot()
+```
+
+### When to use retrospective mode
+
+- Forward mode (default): Use when you have a clear pre/post split and want counterfactual predictions. Standard CausalImpact workflow.
+- Retrospective mode: Use when you want to decompose the treatment effect into spot/persistent/trend directly from the model, or when the treatment timing is known and you want a single-model-fit approach.
+
+### Note on `prior_level_sd`
+
+In retrospective mode, the local level state (random walk) and the persistent
+treatment indicator (step function) are partially collinear. Setting
+`prior_level_sd` to a small value (e.g., 0.001) constrains the state variation
+and forces the model to attribute level shifts to the treatment columns.
+
+---
+
+## Summary of All Examples
+
+All eight examples produce correct results:
 
 - When there is a true effect, the 95% credible interval contains the true value
 - When there is no effect, the model correctly reports non-significance
 - Results are consistent with the R CausalImpact package
+- Retrospective mode extracts treatment components directly from beta posteriors

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,19 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true,
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex",
+  },
+};
+
+document$.subscribe(() => {
+  MathJax.startup.output.clearCache();
+  MathJax.typesetClear();
+  MathJax.texReset();
+  MathJax.typesetPromise();
+});

--- a/docs/theory.md
+++ b/docs/theory.md
@@ -1,0 +1,110 @@
+# Theory: DATE Decomposition
+
+Dynamic Average Treatment Effect (DATE) decomposition separates pointwise
+causal effects into interpretable components.
+
+Reference: Schaffe-Odeleye et al. (2026), "Dynamic Causal Inference with Time
+Series Data", arXiv:2602.00836.
+
+## Motivation
+
+Standard CausalImpact reports a single pointwise effect trajectory
+$\tau_t = y_t - \hat{y}_t$ for each post-intervention time step $t$.
+This answers "how large is the effect at each time?" but not "what type
+of effect is this?"
+
+DATE decomposition answers three distinct questions:
+
+- Did the intervention cause an immediate, one-time impact? (Spot)
+- Did the intervention shift the baseline permanently? (Persistent)
+- Is the effect growing or decaying over time? (Trend)
+
+## Design Matrix
+
+For $T_{\text{post}}$ post-intervention time points, define a design matrix
+$\mathbf{D} \in \mathbb{R}^{T_{\text{post}} \times 3}$:
+
+$$
+\mathbf{D} = \begin{bmatrix}
+1 & 1 & 0 \\
+0 & 1 & 1 \\
+0 & 1 & 2 \\
+\vdots & \vdots & \vdots \\
+0 & 1 & T_{\text{post}}-1
+\end{bmatrix}
+$$
+
+- Column 0 (spot): impulse at $t=0$ only
+- Column 1 (persistent): constant step function from $t=0$ onward
+- Column 2 (trend): linear ramp $0, 1, 2, \ldots, T_{\text{post}}-1$
+
+## OLS Projection
+
+For each MCMC sample $s$, the pointwise effect vector
+$\boldsymbol{\tau}_s \in \mathbb{R}^{T_{\text{post}}}$ is projected:
+
+$$
+\hat{\boldsymbol{\delta}}_s = (\mathbf{D}^\top \mathbf{D})^{-1} \mathbf{D}^\top \boldsymbol{\tau}_s
+$$
+
+In practice, the pseudoinverse $\mathbf{D}^+$ is computed once and applied
+to all samples via matrix multiplication.
+
+The three components of $\hat{\boldsymbol{\delta}}_s$ are
+$(\delta_{\text{spot}}, \delta_{\text{persistent}}, \delta_{\text{trend}})$.
+
+## Posterior Summaries
+
+Component trajectories are reconstructed as:
+
+$$
+\text{spot}_t^{(s)} = \delta_{\text{spot}}^{(s)} \cdot D_{t,0}, \quad
+\text{persistent}_t^{(s)} = \delta_{\text{persistent}}^{(s)} \cdot D_{t,1}, \quad
+\text{trend}_t^{(s)} = \delta_{\text{trend}}^{(s)} \cdot D_{t,2}
+$$
+
+Posterior means and credible intervals are computed across samples.
+
+## Business Examples
+
+| Component | Example scenario |
+|---|---|
+| Spot | Ad campaign launch: immediate spike on day 1, no lasting change |
+| Persistent | Price reduction: permanent baseline shift in daily sales |
+| Trend | New product feature: effect that grows as adoption increases |
+
+## Edge Cases
+
+| Condition | Behavior |
+|---|---|
+| $T_{\text{post}} \geq 3$ | All three components identifiable |
+| $T_{\text{post}} = 2$ | Trend not identifiable; only spot and persistent estimated |
+| $T_{\text{post}} = 1$ | Spot and persistent are collinear; minimum-norm OLS (equal split) |
+
+## Implementation
+
+The decomposition is a pure Python post-processing step applied to the
+existing MCMC output. No changes to the Rust Gibbs sampler are required.
+
+```python
+from causal_impact import CausalImpact
+
+ci = CausalImpact(data, pre_period, post_period)
+dec = ci.decompose()
+
+print(f"Spot:       {dec.spot.coefficient:.2f} [{dec.spot.ci_lower:.2f}, {dec.spot.ci_upper:.2f}]")
+print(f"Persistent: {dec.persistent.coefficient:.2f} [{dec.persistent.ci_lower:.2f}, {dec.persistent.ci_upper:.2f}]")
+if dec.trend is not None:
+    print(f"Trend:      {dec.trend.coefficient:.2f} [{dec.trend.ci_lower:.2f}, {dec.trend.ci_upper:.2f}]")
+```
+
+## Citation
+
+```bibtex
+@article{schaffeodeleye2026dynamic,
+  title   = {Dynamic Causal Inference with Time Series Data},
+  author  = {Schaffe-Odeleye, Ayo and others},
+  journal = {arXiv preprint arXiv:2602.00836},
+  year    = {2026}
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
   - Getting Started: index.md
   - Examples: examples.md
   - API Reference: api.md
+  - Theory (DATE): theory.md
   - Migration from R: migration-from-r.md
   - Migration from tfp: migration-from-tfp.md
   - Compatibility Matrix: compatibility-matrix.md
@@ -30,6 +31,12 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
+  - pymdownx.arithmatex:
+      generic: true
   - admonition
   - pymdownx.details
   - tables
+
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js

--- a/python/causal_impact/__init__.py
+++ b/python/causal_impact/__init__.py
@@ -1,8 +1,16 @@
 """CausalImpact: Causal inference using Bayesian structural time series."""
 
 from causal_impact._core import __version__
+from causal_impact.decomposition import DateDecomposition, EffectComponent
 from causal_impact.main import CausalImpact
 from causal_impact.options import ModelOptions
 from causal_impact.selection import select_controls
 
-__all__ = ["CausalImpact", "ModelOptions", "select_controls", "__version__"]
+__all__ = [
+    "CausalImpact",
+    "DateDecomposition",
+    "EffectComponent",
+    "ModelOptions",
+    "__version__",
+    "select_controls",
+]

--- a/python/causal_impact/decomposition.py
+++ b/python/causal_impact/decomposition.py
@@ -1,0 +1,173 @@
+"""DATE decomposition of pointwise causal effects.
+
+Decomposes the pointwise treatment effect into three components:
+- Spot: immediate impulse at the intervention time point
+- Persistent: sustained level shift from intervention onward
+- Trend: linearly growing/decaying effect over time
+
+For each MCMC sample, OLS projects the pointwise effect vector onto a
+design matrix D, yielding per-sample coefficients. Posterior summaries
+(mean, credible intervals) are computed over these samples.
+
+Reference: Schaffe-Odeleye et al. (2026), arXiv:2602.00836, Eq. (11e).
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+
+import numpy as np
+
+__all__ = [
+    "EffectComponent",
+    "DateDecomposition",
+    "decompose_effects",
+    "build_design_matrix",
+]
+
+
+@dataclass(frozen=True)
+class EffectComponent:
+    """A single decomposed component of the causal effect."""
+
+    name: str
+    coefficient: float
+    ci_lower: float
+    ci_upper: float
+    samples: np.ndarray
+    coefficients: np.ndarray
+    mean: np.ndarray
+    lower: np.ndarray
+    upper: np.ndarray
+
+
+@dataclass(frozen=True)
+class DateDecomposition:
+    """Results of DATE decomposition.
+
+    Reference: Schaffe-Odeleye et al. (2026), arXiv:2602.00836.
+    """
+
+    spot: EffectComponent
+    persistent: EffectComponent
+    trend: EffectComponent | None
+    residual_mean: np.ndarray
+    design_matrix: np.ndarray
+    alpha: float
+
+
+def build_design_matrix(t_post: int, *, include_trend: bool = True) -> np.ndarray:
+    """Construct the DATE design matrix.
+
+    Args:
+        t_post: Number of post-intervention time points.
+        include_trend: Include trend column. Forced False when t_post < 3.
+
+    Returns:
+        D: shape (t_post, n_cols) where n_cols is 2 or 3.
+
+    Raises:
+        ValueError: If t_post < 1.
+    """
+    if t_post < 1:
+        msg = f"t_post must be >= 1, got {t_post}"
+        raise ValueError(msg)
+
+    n_cols = 3 if (include_trend and t_post >= 3) else 2
+    D = np.zeros((t_post, n_cols), dtype=np.float64)
+    D[0, 0] = 1.0
+    D[:, 1] = 1.0
+    if n_cols == 3:
+        D[:, 2] = np.arange(t_post, dtype=np.float64)
+    return D
+
+
+def decompose_effects(
+    effects: np.ndarray,
+    alpha: float = 0.05,
+) -> DateDecomposition:
+    """Decompose pointwise effects into spot, persistent, and trend.
+
+    Args:
+        effects: shape (n_samples, T_post). Each row is a pointwise effect
+            trajectory (y_post - prediction_s) for one MCMC sample.
+        alpha: Significance level for credible intervals.
+
+    Returns:
+        DateDecomposition with per-component posterior summaries.
+
+    Raises:
+        ValueError: If effects is empty.
+
+    Warns:
+        UserWarning: When T_post < 3 (trend not identifiable) or T_post == 1
+            (spot/persistent collinear).
+    """
+    effects = np.asarray(effects, dtype=np.float64)
+    if effects.ndim == 1:
+        effects = effects[np.newaxis, :]
+    n_samples, t_post = effects.shape
+
+    if n_samples == 0:
+        msg = "effects array has 0 samples"
+        raise ValueError(msg)
+    if t_post == 0:
+        msg = "effects array has 0 time points"
+        raise ValueError(msg)
+
+    include_trend = t_post >= 3
+    if not include_trend:
+        warnings.warn(
+            f"T_post={t_post} < 3: trend not identifiable. "
+            "Only spot and persistent are estimated.",
+            UserWarning,
+            stacklevel=2,
+        )
+    if t_post == 1:
+        warnings.warn(
+            "T_post=1: spot and persistent are collinear. "
+            "Minimum-norm OLS solution (equal split). Interpret with caution.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    D = build_design_matrix(t_post, include_trend=include_trend)
+    D_pinv = np.linalg.pinv(D)
+    coefficients = effects @ D_pinv.T
+
+    lower_q = alpha / 2
+    upper_q = 1 - alpha / 2
+
+    def _make(name: str, col: int) -> EffectComponent:
+        coefs = coefficients[:, col]
+        trajs = coefs[:, np.newaxis] * D[:, col]
+        return EffectComponent(
+            name=name,
+            coefficient=float(np.mean(coefs)),
+            ci_lower=float(np.quantile(coefs, lower_q)),
+            ci_upper=float(np.quantile(coefs, upper_q)),
+            samples=trajs,
+            coefficients=coefs,
+            mean=trajs.mean(axis=0),
+            lower=np.quantile(trajs, lower_q, axis=0),
+            upper=np.quantile(trajs, upper_q, axis=0),
+        )
+
+    spot = _make("spot", 0)
+    persistent = _make("persistent", 1)
+    trend = _make("trend", 2) if include_trend else None
+
+    fitted = spot.samples + persistent.samples
+    if trend is not None:
+        fitted = fitted + trend.samples
+    residual_mean = (effects - fitted).mean(axis=0)
+
+    return DateDecomposition(
+        spot=spot,
+        persistent=persistent,
+        trend=trend,
+        residual_mean=residual_mean,
+        design_matrix=D,
+        alpha=alpha,
+    )

--- a/python/causal_impact/main.py
+++ b/python/causal_impact/main.py
@@ -11,9 +11,14 @@ from causal_impact._core import py_run_placebo_test, run_gibbs_sampler
 from causal_impact.analysis import CausalAnalysis, CausalImpactResults
 from causal_impact.conformal import ConformalResults, compute_conformal_intervals
 from causal_impact.data import DataProcessor, PreparedData
+from causal_impact.decomposition import DateDecomposition, decompose_effects
 from causal_impact.options import ModelOptions
 from causal_impact.placebo import PlaceboTestResults
 from causal_impact.plot import Plotter
+from causal_impact.retrospective import (
+    build_treatment_design,
+    extract_treatment_effects,
+)
 from causal_impact.summary import SummaryFormatter
 
 if TYPE_CHECKING:
@@ -80,6 +85,16 @@ class CausalImpact:
     ) -> None:
         args = _normalize_model_args(model_args)
         standardize = args.pop("standardize_data")
+        mode = args.pop("mode", "forward")
+        if mode not in {"forward", "retrospective"}:
+            msg = f"mode must be 'forward' or 'retrospective', got '{mode}'"
+            raise ValueError(msg)
+        if mode == "retrospective" and args.get("dynamic_regression"):
+            msg = (
+                "dynamic_regression is not supported in retrospective mode. "
+                "Use mode='forward' for time-varying coefficients."
+            )
+            raise ValueError(msg)
 
         self._prepared = DataProcessor.validate_and_prepare(
             data, pre_period, post_period, alpha=alpha, standardize=standardize
@@ -88,10 +103,23 @@ class CausalImpact:
         self._data = data if isinstance(data, pd.DataFrame) else pd.DataFrame(data)
         self._pre_period = pre_period
         self._post_period = post_period
+        self._mode = mode
 
         self._model_args = args
-        self._samples = self._run_sampler(self._prepared, args)
-        self._results = self._compute_results(self._prepared, self._samples)
+        self._decomposition: DateDecomposition | None = None
+
+        if mode == "retrospective":
+            self._samples, retro_predictions = self._run_retrospective(
+                self._prepared,
+                args,
+            )
+            self._results = self._compute_results_from_predictions(
+                self._prepared,
+                retro_predictions,
+            )
+        else:
+            self._samples = self._run_sampler(self._prepared, args)
+            self._results = self._compute_results(self._prepared, self._samples)
 
     def _run_sampler(self, prepared: PreparedData, args: dict):
         y_full = np.ascontiguousarray(np.concatenate([prepared.y_pre, prepared.y_post]))
@@ -115,6 +143,89 @@ class CausalImpact:
             season_duration=args["season_duration"],
             dynamic_regression=bool(args.get("dynamic_regression", False)),
             state_model=str(args["state_model"]),
+        )
+
+    def _run_retrospective(self, prepared: PreparedData, args: dict):
+        """Run sampler in retrospective mode: treatment indicators as covariates."""
+        y_full = np.ascontiguousarray(np.concatenate([prepared.y_pre, prepared.y_post]))
+        n_total = len(y_full)
+        intervention_idx = len(prepared.y_pre)
+        t_post = len(prepared.y_post)
+
+        # Build treatment design columns
+        # NOTE: treatment_X is NOT divided by y_sd. The sampler fits on
+        # standardized y, so beta_treat = true_effect / y_sd. The
+        # de-standardization step (beta * y_sd) recovers the original scale.
+        treatment_X = build_treatment_design(n_total, intervention_idx)
+
+        # Stack user covariates + treatment columns
+        if prepared.X_pre is not None and prepared.X_post is not None:
+            X_full = np.vstack([prepared.X_pre, prepared.X_post])
+            X_full = np.hstack([X_full, treatment_X])
+        else:
+            X_full = treatment_X
+
+        x_cols = np.ascontiguousarray(X_full.T)
+        k_total = X_full.shape[1]
+
+        # Force spike-and-slab off: set expected_model_size >= k_total
+        expected_model_size = float(max(args["expected_model_size"], k_total))
+
+        samples = run_gibbs_sampler(
+            y=y_full,
+            x=x_cols,
+            pre_end=n_total,  # Fit on entire series
+            niter=args["niter"],
+            nwarmup=args["nwarmup"],
+            nchains=args["nchains"],
+            seed=args["seed"],
+            prior_level_sd=args["prior_level_sd"],
+            expected_model_size=expected_model_size,
+            nseasons=args["nseasons"],
+            season_duration=args["season_duration"],
+            dynamic_regression=False,  # Not supported in retrospective
+            state_model=str(args["state_model"]),
+        )
+
+        # Extract treatment effects from beta posteriors
+        beta_samples = np.array(samples.beta)
+        treatment_col_start = k_total - 3
+        # De-standardize beta coefficients
+        if prepared.y_sd != 1.0:
+            beta_destd = beta_samples * prepared.y_sd
+        else:
+            beta_destd = beta_samples
+
+        self._decomposition = extract_treatment_effects(
+            beta_destd,
+            treatment_col_start,
+            t_post,
+            alpha=self._alpha,
+        )
+
+        # Construct counterfactual predictions from treatment decomposition
+        # counterfactual = actual - treatment_effect
+        y_post = prepared.y_post * prepared.y_sd + prepared.y_mean
+        treatment_effects = (
+            self._decomposition.spot.samples + self._decomposition.persistent.samples
+        )
+        if self._decomposition.trend is not None:
+            treatment_effects = treatment_effects + self._decomposition.trend.samples
+        predictions = y_post[np.newaxis, :] - treatment_effects
+
+        return samples, predictions
+
+    def _compute_results_from_predictions(
+        self,
+        prepared: PreparedData,
+        predictions: np.ndarray,
+    ) -> CausalImpactResults:
+        """Compute results from pre-built predictions (used by retrospective mode)."""
+        y_post = prepared.y_post * prepared.y_sd + prepared.y_mean
+        return CausalAnalysis.compute_effects(
+            y_post=y_post,
+            predictions=predictions,
+            alpha=self._alpha,
         )
 
     def _compute_results(self, prepared: PreparedData, samples) -> CausalImpactResults:
@@ -154,6 +265,7 @@ class CausalImpact:
             self._prepared.time_index,
             len(self._prepared.y_pre),
             metrics=metrics,
+            decomposition=self._decomposition,
         )
 
     @property
@@ -250,6 +362,47 @@ class CausalImpact:
             real_effect=result.real_effect,
             n_placebos=result.n_placebos,
         )
+
+    def decompose(self, alpha: float | None = None) -> DateDecomposition:
+        """Decompose pointwise effects into spot, persistent, and trend (DATE).
+
+        Based on Schaffe-Odeleye et al. (2026), arXiv:2602.00836.
+
+        In retrospective mode, the decomposition is computed during initialization
+        from beta posteriors. If alpha matches, the cached result is returned.
+        If alpha differs, the decomposition is recomputed from the stored betas.
+
+        Args:
+            alpha: Significance level. Defaults to self._alpha.
+
+        Returns:
+            DateDecomposition with per-component posterior summaries.
+        """
+        if alpha is None:
+            alpha = self._alpha
+
+        if self._mode == "retrospective":
+            if self._decomposition is not None and self._decomposition.alpha == alpha:
+                return self._decomposition
+            # Recompute from stored beta posteriors with new alpha
+            beta_samples = np.array(self._samples.beta)
+            if self._prepared.y_sd != 1.0:
+                beta_samples = beta_samples * self._prepared.y_sd
+            t_post = len(self._prepared.y_post)
+            k_total = beta_samples.shape[1]
+            treatment_col_start = k_total - 3
+            self._decomposition = extract_treatment_effects(
+                beta_samples, treatment_col_start, t_post, alpha=alpha,
+            )
+            return self._decomposition
+
+        predictions = np.array(self._samples.predictions)
+        if self._prepared.y_sd != 1.0 or self._prepared.y_mean != 0.0:
+            predictions = predictions * self._prepared.y_sd + self._prepared.y_mean
+        y_post = self._prepared.y_post * self._prepared.y_sd + self._prepared.y_mean
+        effects = y_post[np.newaxis, :] - predictions
+        self._decomposition = decompose_effects(effects, alpha=alpha)
+        return self._decomposition
 
     def run_conformal_analysis(
         self,

--- a/python/causal_impact/plot.py
+++ b/python/causal_impact/plot.py
@@ -11,12 +11,14 @@ if TYPE_CHECKING:
     from matplotlib.figure import Figure
 
     from causal_impact.analysis import CausalImpactResults
+    from causal_impact.decomposition import DateDecomposition
 
 
 class Plotter:
     """Create matplotlib plots of CausalImpact results."""
 
-    VALID_METRICS = ("original", "pointwise", "cumulative")
+    VALID_METRICS = ("original", "pointwise", "cumulative", "decomposition")
+    DEFAULT_METRICS = ("original", "pointwise", "cumulative")
 
     @staticmethod
     def plot(
@@ -25,11 +27,12 @@ class Plotter:
         time_index: pd.DatetimeIndex | pd.RangeIndex,
         pre_end: int,
         metrics: list[str] | None = None,
+        decomposition: DateDecomposition | None = None,
     ) -> Figure:
         import matplotlib.pyplot as plt
 
         if metrics is None:
-            metrics = list(Plotter.VALID_METRICS)
+            metrics = list(Plotter.DEFAULT_METRICS)
 
         n_panels = len(metrics)
         fig, axes = plt.subplots(n_panels, 1, figsize=(10, 3 * n_panels), sharex=True)
@@ -47,6 +50,14 @@ class Plotter:
                 Plotter._plot_pointwise(ax, post_index, results)
             elif metric == "cumulative":
                 Plotter._plot_cumulative(ax, post_index, results)
+            elif metric == "decomposition":
+                if decomposition is None:
+                    msg = (
+                        "Call ci.decompose() before plotting "
+                        "with 'decomposition' metric."
+                    )
+                    raise ValueError(msg)
+                Plotter._plot_decomposition(ax, post_index, decomposition)
 
             ax.axvline(x=intervention_idx, color="gray", linestyle="--", alpha=0.8)
 
@@ -101,3 +112,21 @@ class Plotter:
         ax.axhline(y=0, color="gray", linestyle="-", alpha=0.5)
         ax.set_ylabel("Cumulative Effect")
         ax.set_title("Cumulative")
+
+    @staticmethod
+    def _plot_decomposition(ax, post_index, decomposition):
+        components = [
+            (decomposition.spot, "#d62728", "Spot"),
+            (decomposition.persistent, "#1f77b4", "Persistent"),
+        ]
+        if decomposition.trend is not None:
+            components.append((decomposition.trend, "#2ca02c", "Trend"))
+
+        for comp, color, label in components:
+            ax.plot(post_index, comp.mean, color=color, linewidth=1, label=label)
+            ax.fill_between(post_index, comp.lower, comp.upper, alpha=0.15, color=color)
+
+        ax.axhline(y=0, color="gray", linestyle="-", alpha=0.5)
+        ax.set_ylabel("Effect Component")
+        ax.set_title("DATE Decomposition")
+        ax.legend(loc="upper left", fontsize=8)

--- a/python/causal_impact/retrospective.py
+++ b/python/causal_impact/retrospective.py
@@ -1,0 +1,98 @@
+"""Retrospective attribution mode for CausalImpact.
+
+In retrospective mode, treatment indicator columns (spot, persistent, trend)
+are added as covariates and the BSTS model is fit on the entire time series.
+Treatment effects are extracted directly from the beta posteriors for the
+treatment columns.
+
+This avoids the counterfactual prediction approach of forward mode and instead
+estimates treatment effects within a single model fit.
+
+Reference: Schaffe-Odeleye et al. (2026), arXiv:2602.00836.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from causal_impact.decomposition import (
+    DateDecomposition,
+    EffectComponent,
+    build_design_matrix,
+)
+
+__all__ = ["build_treatment_design", "extract_treatment_effects"]
+
+
+def build_treatment_design(n_total: int, intervention_idx: int) -> np.ndarray:
+    """Build treatment indicator design matrix for the full time series.
+
+    Args:
+        n_total: Total number of time points.
+        intervention_idx: Index of the first post-intervention time point.
+
+    Returns:
+        D: shape (n_total, 3) with columns [spot, persistent, trend].
+            Pre-intervention rows are all zero.
+    """
+    D = np.zeros((n_total, 3), dtype=np.float64)
+    D[intervention_idx, 0] = 1.0
+    D[intervention_idx:, 1] = 1.0
+    D[intervention_idx:, 2] = np.arange(n_total - intervention_idx, dtype=np.float64)
+    return D
+
+
+def extract_treatment_effects(
+    beta_samples: np.ndarray,
+    treatment_col_start: int,
+    t_post: int,
+    alpha: float = 0.05,
+) -> DateDecomposition:
+    """Extract treatment effect components from beta posterior samples.
+
+    Args:
+        beta_samples: shape (n_samples, k_total). Each row is a beta vector.
+        treatment_col_start: Column index where treatment columns begin.
+            The next 3 columns are [spot, persistent, trend].
+        t_post: Number of post-intervention time points (for trajectory shapes).
+        alpha: Significance level for credible intervals.
+
+    Returns:
+        DateDecomposition with treatment effect components.
+    """
+    lower_q = alpha / 2
+    upper_q = 1 - alpha / 2
+
+    include_trend = t_post >= 3
+    D = build_design_matrix(t_post, include_trend=include_trend)
+
+    def _make(name: str, col_offset: int, d_col: int) -> EffectComponent:
+        coefs = beta_samples[:, treatment_col_start + col_offset]
+        trajs = coefs[:, np.newaxis] * D[:, d_col]
+        return EffectComponent(
+            name=name,
+            coefficient=float(np.mean(coefs)),
+            ci_lower=float(np.quantile(coefs, lower_q)),
+            ci_upper=float(np.quantile(coefs, upper_q)),
+            samples=trajs,
+            coefficients=coefs,
+            mean=trajs.mean(axis=0),
+            lower=np.quantile(trajs, lower_q, axis=0),
+            upper=np.quantile(trajs, upper_q, axis=0),
+        )
+
+    spot = _make("spot", 0, 0)
+    persistent = _make("persistent", 1, 1)
+    trend = _make("trend", 2, 2) if include_trend else None
+
+    # In retrospective mode, residual is zero by construction
+    residual_mean = np.zeros(t_post)
+
+    return DateDecomposition(
+        spot=spot,
+        persistent=persistent,
+        trend=trend,
+        residual_mean=residual_mean,
+        design_matrix=D,
+        alpha=alpha,
+    )

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -100,8 +100,8 @@ fn validate_inputs(y: &[f64], pre_end: usize, nchains: usize) -> Result<(), Stri
     if pre_end == 0 {
         return Err("pre_end must be at least 1".to_string());
     }
-    if pre_end >= y.len() {
-        return Err("pre_end must be less than length of y (no post-period)".to_string());
+    if pre_end > y.len() {
+        return Err("pre_end must be <= length of y".to_string());
     }
     if nchains == 0 {
         return Err("nchains must be at least 1".to_string());
@@ -1808,11 +1808,38 @@ mod tests {
 
     #[test]
     fn test_run_sampler_pre_end_equals_t() {
+        // pre_end == y.len() is valid for retrospective mode (no post-period).
         let y: Vec<f64> = vec![1.0, 2.0, 3.0];
         let result = run_sampler(
             &y,
             vec![],
             3,
+            10,
+            5,
+            1,
+            42,
+            0.01,
+            1.0,
+            None,
+            None,
+            false,
+            "local_level",
+        );
+        assert!(result.is_ok());
+        let gibbs = result.unwrap();
+        // Predictions should be empty (no post-period)
+        for pred in &gibbs.predictions {
+            assert!(pred.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_run_sampler_pre_end_exceeds_t() {
+        let y: Vec<f64> = vec![1.0, 2.0, 3.0];
+        let result = run_sampler(
+            &y,
+            vec![],
+            4,
             10,
             5,
             1,

--- a/tests/test_decomposition.py
+++ b/tests/test_decomposition.py
@@ -1,0 +1,389 @@
+"""Tests for DATE decomposition of pointwise causal effects.
+
+What: Verify that decompose_effects correctly separates pointwise effects
+into spot, persistent, and trend components via OLS projection.
+
+Reference: Schaffe-Odeleye et al. (2026), arXiv:2602.00836, Eq. (11e).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from causal_impact.decomposition import (
+    DateDecomposition,
+    EffectComponent,
+    build_design_matrix,
+    decompose_effects,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_effects(
+    n_samples: int,
+    t_post: int,
+    beta_spot: float,
+    beta_persistent: float,
+    beta_trend: float = 0.0,
+    noise_sd: float = 0.0,
+    seed: int = 42,
+) -> np.ndarray:
+    """Synthesise effect trajectories from known coefficients."""
+    rng = np.random.default_rng(seed)
+    D = build_design_matrix(t_post, include_trend=(t_post >= 3))
+    beta = np.array([beta_spot, beta_persistent, beta_trend][: D.shape[1]])
+    signal = D @ beta
+    noise = rng.normal(0, noise_sd, (n_samples, t_post)) if noise_sd > 0 else 0.0
+    return np.tile(signal, (n_samples, 1)) + noise
+
+
+# ---------------------------------------------------------------------------
+# TestBuildDesignMatrix
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDesignMatrix:
+    @pytest.mark.parametrize(
+        "t_post, expected_cols",
+        [(1, 2), (2, 2), (3, 3), (10, 3), (100, 3)],
+    )
+    def test_shape_parametrized(self, t_post, expected_cols):
+        D = build_design_matrix(t_post)
+        assert D.shape == (t_post, expected_cols)
+
+    def test_spot_column_impulse(self):
+        D = build_design_matrix(5)
+        expected = np.array([1.0, 0.0, 0.0, 0.0, 0.0])
+        np.testing.assert_array_equal(D[:, 0], expected)
+
+    def test_persistent_column_ones(self):
+        D = build_design_matrix(5)
+        np.testing.assert_array_equal(D[:, 1], np.ones(5))
+
+    def test_trend_column_ramp(self):
+        D = build_design_matrix(5)
+        np.testing.assert_array_equal(D[:, 2], np.arange(5, dtype=np.float64))
+
+    def test_tpost1_shape_2cols(self):
+        D = build_design_matrix(1)
+        assert D.shape == (1, 2)
+
+    def test_tpost0_raises(self):
+        with pytest.raises(ValueError, match="t_post must be >= 1"):
+            build_design_matrix(0)
+
+    def test_include_trend_false(self):
+        D = build_design_matrix(10, include_trend=False)
+        assert D.shape == (10, 2)
+
+    def test_dtype_float64(self):
+        D = build_design_matrix(5)
+        assert D.dtype == np.float64
+
+
+# ---------------------------------------------------------------------------
+# TestDecomposeRecovery
+# ---------------------------------------------------------------------------
+
+
+class TestDecomposeRecovery:
+    @pytest.mark.parametrize(
+        "beta_spot, beta_persistent, beta_trend",
+        [
+            (5.0, 0.0, 0.0),
+            (0.0, 3.0, 0.0),
+            (0.0, 0.0, 1.0),
+            (2.0, 3.0, 0.5),
+            (-1.0, 4.0, -0.2),
+        ],
+    )
+    def test_noiseless_parametrized(self, beta_spot, beta_persistent, beta_trend):
+        t_post = 10
+        effects = _make_effects(100, t_post, beta_spot, beta_persistent, beta_trend)
+        result = decompose_effects(effects)
+        assert result.spot.coefficient == pytest.approx(beta_spot, abs=1e-12)
+        assert result.persistent.coefficient == pytest.approx(beta_persistent, abs=1e-12)
+        assert result.trend is not None
+        assert result.trend.coefficient == pytest.approx(beta_trend, abs=1e-12)
+
+    def test_noisy_mean_close(self):
+        effects = _make_effects(5000, 20, 3.0, 2.0, 0.5, noise_sd=0.5)
+        result = decompose_effects(effects)
+        assert result.spot.coefficient == pytest.approx(3.0, abs=0.1)
+        assert result.persistent.coefficient == pytest.approx(2.0, abs=0.1)
+        assert result.trend.coefficient == pytest.approx(0.5, abs=0.1)
+
+    def test_residual_zero_noiseless(self):
+        effects = _make_effects(100, 10, 2.0, 1.0, 0.3)
+        result = decompose_effects(effects)
+        np.testing.assert_allclose(result.residual_mean, 0.0, atol=1e-12)
+
+    def test_components_sum_to_original(self):
+        effects = _make_effects(200, 15, 1.5, 2.5, 0.4, noise_sd=0.3, seed=7)
+        result = decompose_effects(effects)
+        reconstructed = result.spot.mean + result.persistent.mean
+        if result.trend is not None:
+            reconstructed = reconstructed + result.trend.mean
+        reconstructed = reconstructed + result.residual_mean
+        np.testing.assert_allclose(reconstructed, effects.mean(axis=0), atol=1e-10)
+
+    def test_spot_trajectory_is_impulse_scaled(self):
+        effects = _make_effects(50, 8, 5.0, 0.0, 0.0)
+        result = decompose_effects(effects)
+        expected = np.zeros(8)
+        expected[0] = 5.0
+        np.testing.assert_allclose(result.spot.mean, expected, atol=1e-10)
+
+    def test_persistent_trajectory_is_step(self):
+        effects = _make_effects(50, 8, 0.0, 3.0, 0.0)
+        result = decompose_effects(effects)
+        np.testing.assert_allclose(result.persistent.mean, np.full(8, 3.0), atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# TestDecomposeShortPost
+# ---------------------------------------------------------------------------
+
+
+class TestDecomposeShortPost:
+    def test_tpost2_trend_is_none(self):
+        effects = _make_effects(100, 2, 1.0, 2.0)
+        result = decompose_effects(effects)
+        assert result.trend is None
+
+    def test_tpost2_spot_persistent_recovered(self):
+        effects = _make_effects(100, 2, 1.0, 2.0)
+        with pytest.warns(UserWarning, match="T_post=2 < 3"):
+            result = decompose_effects(effects)
+        assert result.spot.coefficient == pytest.approx(1.0, abs=1e-10)
+        assert result.persistent.coefficient == pytest.approx(2.0, abs=1e-10)
+
+    def test_tpost2_emits_warning(self):
+        effects = _make_effects(100, 2, 1.0, 2.0)
+        with pytest.warns(UserWarning, match="T_post=2 < 3"):
+            decompose_effects(effects)
+
+    def test_tpost1_trend_is_none(self):
+        effects = np.full((100, 1), 4.0)
+        with pytest.warns(UserWarning):
+            result = decompose_effects(effects)
+        assert result.trend is None
+
+    def test_tpost1_emits_collinearity_warning(self):
+        effects = np.full((100, 1), 4.0)
+        with pytest.warns(UserWarning, match="collinear"):
+            decompose_effects(effects)
+
+    def test_tpost1_equal_split(self):
+        effects = np.full((100, 1), 4.0)
+        with pytest.warns(UserWarning):
+            result = decompose_effects(effects)
+        assert result.spot.coefficient == pytest.approx(2.0, abs=1e-10)
+        assert result.persistent.coefficient == pytest.approx(2.0, abs=1e-10)
+
+    def test_tpost1_coefficients_sum_to_effect(self):
+        effects = np.full((100, 1), 6.0)
+        with pytest.warns(UserWarning):
+            result = decompose_effects(effects)
+        total = result.spot.coefficient + result.persistent.coefficient
+        assert total == pytest.approx(6.0, abs=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# TestDecomposeEdgeCases
+# ---------------------------------------------------------------------------
+
+
+class TestDecomposeEdgeCases:
+    def test_nsamples0_raises(self):
+        with pytest.raises(ValueError, match="0 samples"):
+            decompose_effects(np.empty((0, 5)))
+
+    def test_tpost0_raises(self):
+        with pytest.raises(ValueError, match="0 time points"):
+            decompose_effects(np.empty((10, 0)))
+
+    def test_single_sample_ci_collapses(self):
+        effects = _make_effects(1, 10, 2.0, 1.0, 0.5)
+        result = decompose_effects(effects)
+        assert result.spot.ci_lower == result.spot.coefficient
+        assert result.spot.ci_upper == result.spot.coefficient
+
+    def test_1d_input_promoted(self):
+        effects_1d = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        result = decompose_effects(effects_1d)
+        assert result.spot.samples.shape[0] == 1
+
+    def test_frozen_dataclass_immutable(self):
+        effects = _make_effects(50, 5, 1.0, 1.0, 0.1)
+        result = decompose_effects(effects)
+        with pytest.raises(AttributeError):
+            result.spot = None  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# TestDecomposeCI
+# ---------------------------------------------------------------------------
+
+
+class TestDecomposeCI:
+    def test_lower_le_mean_le_upper(self):
+        effects = _make_effects(500, 10, 2.0, 1.0, 0.3, noise_sd=0.5)
+        result = decompose_effects(effects)
+        for comp in [result.spot, result.persistent, result.trend]:
+            assert comp is not None
+            assert comp.ci_lower <= comp.coefficient <= comp.ci_upper
+
+    def test_alpha01_wider_than_alpha05(self):
+        effects = _make_effects(500, 10, 2.0, 1.0, 0.3, noise_sd=0.5)
+        r01 = decompose_effects(effects, alpha=0.01)
+        r05 = decompose_effects(effects, alpha=0.05)
+        width_01 = r01.spot.ci_upper - r01.spot.ci_lower
+        width_05 = r05.spot.ci_upper - r05.spot.ci_lower
+        assert width_01 >= width_05
+
+    def test_alpha_stored(self):
+        effects = _make_effects(50, 5, 1.0, 1.0, 0.1)
+        result = decompose_effects(effects, alpha=0.10)
+        assert result.alpha == 0.10
+
+
+# ---------------------------------------------------------------------------
+# TestIntegrationWithCausalImpact
+# ---------------------------------------------------------------------------
+
+
+def _make_ci_data(t_pre=50, t_post=20, effect=5.0, seed=42):
+    rng = np.random.default_rng(seed)
+    y = np.cumsum(rng.normal(0, 1, t_pre + t_post)) + 100
+    y[t_pre:] += effect
+    df = pd.DataFrame({"y": y})
+    return df, [0, t_pre - 1], [t_pre, t_pre + t_post - 1]
+
+
+class TestIntegrationWithCausalImpact:
+    def test_returns_date_decomposition(self):
+        from causal_impact import CausalImpact
+
+        df, pre, post = _make_ci_data()
+        ci = CausalImpact(df, pre, post, model_args={"niter": 100, "nwarmup": 50})
+        result = ci.decompose()
+        assert isinstance(result, DateDecomposition)
+
+    def test_spot_shape_matches_tpost(self):
+        from causal_impact import CausalImpact
+
+        t_post = 15
+        df, pre, post = _make_ci_data(t_post=t_post)
+        ci = CausalImpact(df, pre, post, model_args={"niter": 100, "nwarmup": 50})
+        result = ci.decompose()
+        assert result.spot.mean.shape == (t_post,)
+
+    def test_stores_on_instance(self):
+        from causal_impact import CausalImpact
+
+        df, pre, post = _make_ci_data()
+        ci = CausalImpact(df, pre, post, model_args={"niter": 100, "nwarmup": 50})
+        ci.decompose()
+        assert ci._decomposition is not None
+
+    def test_default_alpha(self):
+        from causal_impact import CausalImpact
+
+        df, pre, post = _make_ci_data()
+        ci = CausalImpact(df, pre, post, model_args={"niter": 100, "nwarmup": 50})
+        result = ci.decompose()
+        assert result.alpha == 0.05
+
+    def test_custom_alpha(self):
+        from causal_impact import CausalImpact
+
+        df, pre, post = _make_ci_data()
+        ci = CausalImpact(
+            df, pre, post, model_args={"niter": 100, "nwarmup": 50}, alpha=0.10
+        )
+        result = ci.decompose(alpha=0.01)
+        assert result.alpha == 0.01
+
+    def test_short_post_warns(self):
+        from causal_impact import CausalImpact
+
+        df, pre, post = _make_ci_data(t_post=2)
+        ci = CausalImpact(df, pre, post, model_args={"niter": 100, "nwarmup": 50})
+        with pytest.warns(UserWarning, match="T_post=2 < 3"):
+            ci.decompose()
+
+
+# ---------------------------------------------------------------------------
+# TestPlotDecomposition
+# ---------------------------------------------------------------------------
+
+
+class TestPlotDecomposition:
+    @pytest.fixture()
+    def _ci_with_decomposition(self):
+        import matplotlib
+
+        matplotlib.use("Agg")
+        from causal_impact import CausalImpact
+
+        df, pre, post = _make_ci_data(t_post=20)
+        ci = CausalImpact(df, pre, post, model_args={"niter": 100, "nwarmup": 50})
+        ci.decompose()
+        return ci
+
+    def test_panel_exists(self, _ci_with_decomposition):
+        ci = _ci_with_decomposition
+        fig = ci.plot(metrics=["original", "pointwise", "cumulative", "decomposition"])
+        assert len(fig.get_axes()) == 4
+
+    def test_3_lines_with_trend(self, _ci_with_decomposition):
+        ci = _ci_with_decomposition
+        fig = ci.plot(metrics=["decomposition"])
+        ax = fig.get_axes()[0]
+        # 3 component lines + 1 hline + 1 axvline (intervention) = 5 lines
+        assert len(ax.get_lines()) == 5
+
+    def test_2_lines_without_trend(self):
+        import matplotlib
+
+        matplotlib.use("Agg")
+        from causal_impact import CausalImpact
+
+        df, pre, post = _make_ci_data(t_post=2)
+        ci = CausalImpact(df, pre, post, model_args={"niter": 100, "nwarmup": 50})
+        with pytest.warns(UserWarning):
+            ci.decompose()
+        fig = ci.plot(metrics=["decomposition"])
+        ax = fig.get_axes()[0]
+        # 2 component lines + 1 hline + 1 axvline (intervention) = 4 lines
+        assert len(ax.get_lines()) == 4
+
+    def test_ci_bands(self, _ci_with_decomposition):
+        ci = _ci_with_decomposition
+        fig = ci.plot(metrics=["decomposition"])
+        ax = fig.get_axes()[0]
+        # 3 fill_between collections (spot, persistent, trend)
+        assert len(ax.collections) == 3
+
+    def test_without_decompose_raises(self):
+        import matplotlib
+
+        matplotlib.use("Agg")
+        from causal_impact import CausalImpact
+
+        df, pre, post = _make_ci_data()
+        ci = CausalImpact(df, pre, post, model_args={"niter": 100, "nwarmup": 50})
+        with pytest.raises(ValueError, match="decompose"):
+            ci.plot(metrics=["decomposition"])
+
+    def test_mixed_metrics(self, _ci_with_decomposition):
+        ci = _ci_with_decomposition
+        fig = ci.plot(metrics=["pointwise", "decomposition"])
+        assert len(fig.get_axes()) == 2

--- a/tests/test_decomposition.py
+++ b/tests/test_decomposition.py
@@ -11,14 +11,11 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 import pytest
-
 from causal_impact.decomposition import (
     DateDecomposition,
-    EffectComponent,
     build_design_matrix,
     decompose_effects,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -108,7 +105,10 @@ class TestDecomposeRecovery:
         effects = _make_effects(100, t_post, beta_spot, beta_persistent, beta_trend)
         result = decompose_effects(effects)
         assert result.spot.coefficient == pytest.approx(beta_spot, abs=1e-12)
-        assert result.persistent.coefficient == pytest.approx(beta_persistent, abs=1e-12)
+        assert result.persistent.coefficient == pytest.approx(
+            beta_persistent,
+            abs=1e-12,
+        )
         assert result.trend is not None
         assert result.trend.coefficient == pytest.approx(beta_trend, abs=1e-12)
 

--- a/tests/test_retrospective.py
+++ b/tests/test_retrospective.py
@@ -1,0 +1,322 @@
+"""Tests for retrospective attribution mode.
+
+What: Verify that mode="retrospective" correctly identifies treatment effects
+by including treatment indicator columns as covariates and fitting the BSTS
+model on the entire time series.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from causal_impact import CausalImpact
+from causal_impact.decomposition import DateDecomposition
+from causal_impact.retrospective import build_treatment_design, extract_treatment_effects
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_retrospective_data(
+    t_pre: int = 100,
+    t_post: int = 30,
+    beta_persistent: float = 5.0,
+    beta_spot: float = 0.0,
+    beta_trend: float = 0.0,
+    noise_sd: float = 1.0,
+    seed: int = 42,
+    with_covariate: bool = False,
+):
+    """Synthesise data with known treatment effect injected via design columns."""
+    rng = np.random.default_rng(seed)
+    n = t_pre + t_post
+
+    # Base process: local level + covariate
+    if with_covariate:
+        x = np.zeros(n)
+        x[0] = 100
+        for t in range(1, n):
+            x[t] = 0.999 * x[t - 1] + rng.normal(0, 1)
+        y = 1.2 * x + rng.normal(0, noise_sd, size=n)
+    else:
+        y = np.cumsum(rng.normal(0, 0.3, n)) + 50
+        y += rng.normal(0, noise_sd, n)
+        x = None
+
+    # Inject treatment effect
+    D = build_treatment_design(n, t_pre)
+    treatment = D @ np.array([beta_spot, beta_persistent, beta_trend])
+    y += treatment
+
+    if with_covariate:
+        df = pd.DataFrame({"y": y, "x": x})
+    else:
+        df = pd.DataFrame({"y": y})
+
+    return df, [0, t_pre - 1], [t_pre, n - 1], t_pre
+
+
+# ---------------------------------------------------------------------------
+# TestBuildTreatmentDesign
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTreatmentDesign:
+    def test_shape(self):
+        D = build_treatment_design(100, 70)
+        assert D.shape == (100, 3)
+
+    def test_spot_column(self):
+        D = build_treatment_design(10, 5)
+        expected = np.zeros(10)
+        expected[5] = 1.0
+        np.testing.assert_array_equal(D[:, 0], expected)
+
+    def test_persistent_column(self):
+        D = build_treatment_design(10, 5)
+        expected = np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1], dtype=float)
+        np.testing.assert_array_equal(D[:, 1], expected)
+
+    def test_trend_column(self):
+        D = build_treatment_design(10, 5)
+        expected = np.array([0, 0, 0, 0, 0, 0, 1, 2, 3, 4], dtype=float)
+        np.testing.assert_array_equal(D[:, 2], expected)
+
+    def test_pre_period_all_zero(self):
+        D = build_treatment_design(20, 10)
+        np.testing.assert_array_equal(D[:10, :], 0.0)
+
+
+# ---------------------------------------------------------------------------
+# TestExtractTreatmentEffects
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTreatmentEffects:
+    def test_returns_date_decomposition(self):
+        rng = np.random.default_rng(42)
+        beta_samples = rng.normal(0, 1, (100, 5))
+        result = extract_treatment_effects(beta_samples, treatment_col_start=2, t_post=30)
+        assert isinstance(result, DateDecomposition)
+
+    def test_correct_coefficients_extracted(self):
+        n_samples = 200
+        # Columns: [x1, x2, spot, persistent, trend]
+        beta_samples = np.zeros((n_samples, 5))
+        beta_samples[:, 2] = 3.0  # spot
+        beta_samples[:, 3] = 5.0  # persistent
+        beta_samples[:, 4] = 0.1  # trend
+        result = extract_treatment_effects(beta_samples, treatment_col_start=2, t_post=20)
+        assert result.spot.coefficient == pytest.approx(3.0, abs=1e-10)
+        assert result.persistent.coefficient == pytest.approx(5.0, abs=1e-10)
+        assert result.trend.coefficient == pytest.approx(0.1, abs=1e-10)
+
+    def test_trajectory_shapes(self):
+        beta_samples = np.random.default_rng(42).normal(0, 1, (50, 3))
+        result = extract_treatment_effects(beta_samples, treatment_col_start=0, t_post=15)
+        assert result.spot.mean.shape == (15,)
+        assert result.persistent.mean.shape == (15,)
+        assert result.trend.mean.shape == (15,)
+
+
+# ---------------------------------------------------------------------------
+# TestRetrospectiveCausalImpact
+# ---------------------------------------------------------------------------
+
+
+class TestRetrospectiveCausalImpact:
+    def test_known_persistent_effect(self):
+        """Known level shift: persistent coefficient should be in a reasonable range.
+
+        Due to partial collinearity between the local level state and the
+        persistent treatment indicator, exact recovery is not guaranteed.
+        We check the estimate is within ±50% of the true value.
+        """
+        df, pre, post, _ = _make_retrospective_data(
+            beta_persistent=5.0, noise_sd=0.5, seed=42, t_pre=200, t_post=50,
+        )
+        ci = CausalImpact(
+            df, pre, post,
+            model_args={
+                "niter": 2000, "nwarmup": 1000, "seed": 42,
+                "mode": "retrospective", "prior_level_sd": 0.001,
+            },
+        )
+        dec = ci._decomposition
+        assert dec is not None
+        # Persistent + spot at t=0 should sum to roughly the true effect
+        total_at_intervention = dec.persistent.coefficient + dec.spot.coefficient
+        assert abs(total_at_intervention - 5.0) < 5.0
+
+    def test_known_trend_effect(self):
+        """Known trend: trend coefficient should be positive and non-trivial."""
+        df, pre, post, _ = _make_retrospective_data(
+            beta_persistent=0.0, beta_trend=0.5, noise_sd=0.5,
+            seed=77, t_pre=200, t_post=50,
+        )
+        ci = CausalImpact(
+            df, pre, post,
+            model_args={
+                "niter": 2000, "nwarmup": 1000, "seed": 77,
+                "mode": "retrospective", "prior_level_sd": 0.001,
+            },
+        )
+        dec = ci._decomposition
+        assert dec is not None
+        # Trend should be positive (true value 0.5)
+        assert dec.trend.coefficient > 0.0
+
+    def test_zero_effect_includes_zero(self):
+        """No effect: persistent coefficient should be close to zero."""
+        df, pre, post, _ = _make_retrospective_data(
+            beta_persistent=0.0, beta_spot=0.0, beta_trend=0.0,
+            noise_sd=0.5, seed=99, t_pre=150, t_post=50,
+        )
+        ci = CausalImpact(
+            df, pre, post,
+            model_args={
+                "niter": 1000, "nwarmup": 500, "seed": 99,
+                "mode": "retrospective", "prior_level_sd": 0.001,
+            },
+        )
+        dec = ci._decomposition
+        assert dec is not None
+        # Should be close to zero (within a few units)
+        assert abs(dec.persistent.coefficient) < 3.0
+
+    def test_spike_slab_auto_disabled(self):
+        """Spike-and-slab should be auto-disabled in retrospective mode."""
+        df, pre, post, _ = _make_retrospective_data(
+            beta_persistent=3.0, with_covariate=True,
+        )
+        ci = CausalImpact(
+            df, pre, post,
+            model_args={
+                "niter": 200, "nwarmup": 100, "seed": 42,
+                "mode": "retrospective", "expected_model_size": 1,
+            },
+        )
+        # Should have run without error; gamma should be empty or all-True
+        # because spike-and-slab was force-disabled
+        assert ci._decomposition is not None
+
+    def test_with_covariate(self):
+        """Retrospective with an additional covariate should still work."""
+        df, pre, post, _ = _make_retrospective_data(
+            beta_persistent=5.0, with_covariate=True,
+            noise_sd=0.5, seed=42, t_pre=200, t_post=50,
+        )
+        ci = CausalImpact(
+            df, pre, post,
+            model_args={
+                "niter": 2000, "nwarmup": 1000, "seed": 42,
+                "mode": "retrospective", "prior_level_sd": 0.001,
+            },
+        )
+        dec = ci._decomposition
+        assert dec is not None
+        # Persistent + spot should sum to roughly the true effect
+        # Due to collinearity with local level and covariate, wide tolerance
+        total_at_intervention = dec.persistent.coefficient + dec.spot.coefficient
+        assert abs(total_at_intervention - 5.0) < 5.0
+
+    def test_forward_decompose_still_works(self):
+        """Forward mode decompose() should still work after retrospective is added."""
+        df, pre, post, _ = _make_retrospective_data(beta_persistent=5.0)
+        ci = CausalImpact(df, pre, post, model_args={"niter": 100, "nwarmup": 50})
+        result = ci.decompose()
+        assert isinstance(result, DateDecomposition)
+
+    def test_existing_tests_unchanged(self):
+        """Ensure forward mode default behavior is unchanged."""
+        rng = np.random.default_rng(42)
+        n = 130
+        y = np.cumsum(rng.normal(0, 1, n)) + 100
+        y[100:] += 5.0
+        df = pd.DataFrame({"y": y})
+        ci = CausalImpact(df, [0, 99], [100, 129], model_args={"niter": 100, "nwarmup": 50})
+        assert ci._decomposition is None
+        assert hasattr(ci, "decompose")
+
+    def test_decompose_returns_cached_in_retrospective(self):
+        """decompose() should return the cached decomposition in retrospective mode."""
+        df, pre, post, _ = _make_retrospective_data(
+            beta_persistent=3.0, noise_sd=0.5, seed=42, t_pre=100, t_post=30,
+        )
+        ci = CausalImpact(
+            df, pre, post,
+            model_args={
+                "niter": 200, "nwarmup": 100, "seed": 42,
+                "mode": "retrospective", "prior_level_sd": 0.001,
+            },
+        )
+        # decompose() should work without crashing
+        dec = ci.decompose()
+        assert isinstance(dec, DateDecomposition)
+        assert dec is ci._decomposition
+
+    def test_decompose_recomputes_with_different_alpha(self):
+        """decompose(alpha=0.1) should recompute with new credible intervals."""
+        df, pre, post, _ = _make_retrospective_data(
+            beta_persistent=3.0, noise_sd=0.5, seed=42, t_pre=100, t_post=30,
+        )
+        ci = CausalImpact(
+            df, pre, post,
+            model_args={
+                "niter": 200, "nwarmup": 100, "seed": 42,
+                "mode": "retrospective", "prior_level_sd": 0.001,
+            },
+        )
+        dec_05 = ci.decompose(alpha=0.05)
+        dec_10 = ci.decompose(alpha=0.10)
+        assert dec_10.alpha == 0.10
+        # 90% CI should be narrower than 95% CI
+        assert dec_10.persistent.ci_upper - dec_10.persistent.ci_lower <= (
+            dec_05.persistent.ci_upper - dec_05.persistent.ci_lower
+        )
+
+    def test_short_post_period_no_crash(self):
+        """Retrospective with t_post=2 should not crash (trend=None)."""
+        df, pre, post, _ = _make_retrospective_data(
+            beta_persistent=3.0, noise_sd=0.5, seed=42, t_pre=50, t_post=2,
+        )
+        ci = CausalImpact(
+            df, pre, post,
+            model_args={
+                "niter": 100, "nwarmup": 50, "seed": 42,
+                "mode": "retrospective", "prior_level_sd": 0.001,
+            },
+        )
+        dec = ci._decomposition
+        assert dec is not None
+        assert dec.trend is None
+        assert dec.spot.mean.shape == (2,)
+        assert dec.persistent.mean.shape == (2,)
+
+    def test_dynamic_regression_retrospective_raises(self):
+        """dynamic_regression=True should raise in retrospective mode."""
+        rng = np.random.default_rng(42)
+        y = np.cumsum(rng.normal(0, 1, 50)) + 100
+        df = pd.DataFrame({"y": y})
+        with pytest.raises(ValueError, match="dynamic_regression"):
+            CausalImpact(
+                df, [0, 29], [30, 49],
+                model_args={
+                    "niter": 100, "nwarmup": 50,
+                    "mode": "retrospective", "dynamic_regression": True,
+                },
+            )
+
+    def test_invalid_mode_raises(self):
+        rng = np.random.default_rng(42)
+        y = np.cumsum(rng.normal(0, 1, 50)) + 100
+        df = pd.DataFrame({"y": y})
+        with pytest.raises(ValueError, match="mode"):
+            CausalImpact(
+                df, [0, 29], [30, 49],
+                model_args={"niter": 100, "nwarmup": 50, "mode": "invalid"},
+            )

--- a/tests/test_retrospective.py
+++ b/tests/test_retrospective.py
@@ -10,11 +10,12 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 import pytest
-
 from causal_impact import CausalImpact
 from causal_impact.decomposition import DateDecomposition
-from causal_impact.retrospective import build_treatment_design, extract_treatment_effects
-
+from causal_impact.retrospective import (
+    build_treatment_design,
+    extract_treatment_effects,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -100,7 +101,11 @@ class TestExtractTreatmentEffects:
     def test_returns_date_decomposition(self):
         rng = np.random.default_rng(42)
         beta_samples = rng.normal(0, 1, (100, 5))
-        result = extract_treatment_effects(beta_samples, treatment_col_start=2, t_post=30)
+        result = extract_treatment_effects(
+            beta_samples,
+            treatment_col_start=2,
+            t_post=30,
+        )
         assert isinstance(result, DateDecomposition)
 
     def test_correct_coefficients_extracted(self):
@@ -110,14 +115,22 @@ class TestExtractTreatmentEffects:
         beta_samples[:, 2] = 3.0  # spot
         beta_samples[:, 3] = 5.0  # persistent
         beta_samples[:, 4] = 0.1  # trend
-        result = extract_treatment_effects(beta_samples, treatment_col_start=2, t_post=20)
+        result = extract_treatment_effects(
+            beta_samples,
+            treatment_col_start=2,
+            t_post=20,
+        )
         assert result.spot.coefficient == pytest.approx(3.0, abs=1e-10)
         assert result.persistent.coefficient == pytest.approx(5.0, abs=1e-10)
         assert result.trend.coefficient == pytest.approx(0.1, abs=1e-10)
 
     def test_trajectory_shapes(self):
         beta_samples = np.random.default_rng(42).normal(0, 1, (50, 3))
-        result = extract_treatment_effects(beta_samples, treatment_col_start=0, t_post=15)
+        result = extract_treatment_effects(
+            beta_samples,
+            treatment_col_start=0,
+            t_post=15,
+        )
         assert result.spot.mean.shape == (15,)
         assert result.persistent.mean.shape == (15,)
         assert result.trend.mean.shape == (15,)
@@ -137,13 +150,22 @@ class TestRetrospectiveCausalImpact:
         We check the estimate is within ±50% of the true value.
         """
         df, pre, post, _ = _make_retrospective_data(
-            beta_persistent=5.0, noise_sd=0.5, seed=42, t_pre=200, t_post=50,
+            beta_persistent=5.0,
+            noise_sd=0.5,
+            seed=42,
+            t_pre=200,
+            t_post=50,
         )
         ci = CausalImpact(
-            df, pre, post,
+            df,
+            pre,
+            post,
             model_args={
-                "niter": 2000, "nwarmup": 1000, "seed": 42,
-                "mode": "retrospective", "prior_level_sd": 0.001,
+                "niter": 2000,
+                "nwarmup": 1000,
+                "seed": 42,
+                "mode": "retrospective",
+                "prior_level_sd": 0.001,
             },
         )
         dec = ci._decomposition
@@ -155,14 +177,23 @@ class TestRetrospectiveCausalImpact:
     def test_known_trend_effect(self):
         """Known trend: trend coefficient should be positive and non-trivial."""
         df, pre, post, _ = _make_retrospective_data(
-            beta_persistent=0.0, beta_trend=0.5, noise_sd=0.5,
-            seed=77, t_pre=200, t_post=50,
+            beta_persistent=0.0,
+            beta_trend=0.5,
+            noise_sd=0.5,
+            seed=77,
+            t_pre=200,
+            t_post=50,
         )
         ci = CausalImpact(
-            df, pre, post,
+            df,
+            pre,
+            post,
             model_args={
-                "niter": 2000, "nwarmup": 1000, "seed": 77,
-                "mode": "retrospective", "prior_level_sd": 0.001,
+                "niter": 2000,
+                "nwarmup": 1000,
+                "seed": 77,
+                "mode": "retrospective",
+                "prior_level_sd": 0.001,
             },
         )
         dec = ci._decomposition
@@ -173,14 +204,24 @@ class TestRetrospectiveCausalImpact:
     def test_zero_effect_includes_zero(self):
         """No effect: persistent coefficient should be close to zero."""
         df, pre, post, _ = _make_retrospective_data(
-            beta_persistent=0.0, beta_spot=0.0, beta_trend=0.0,
-            noise_sd=0.5, seed=99, t_pre=150, t_post=50,
+            beta_persistent=0.0,
+            beta_spot=0.0,
+            beta_trend=0.0,
+            noise_sd=0.5,
+            seed=99,
+            t_pre=150,
+            t_post=50,
         )
         ci = CausalImpact(
-            df, pre, post,
+            df,
+            pre,
+            post,
             model_args={
-                "niter": 1000, "nwarmup": 500, "seed": 99,
-                "mode": "retrospective", "prior_level_sd": 0.001,
+                "niter": 1000,
+                "nwarmup": 500,
+                "seed": 99,
+                "mode": "retrospective",
+                "prior_level_sd": 0.001,
             },
         )
         dec = ci._decomposition
@@ -191,13 +232,19 @@ class TestRetrospectiveCausalImpact:
     def test_spike_slab_auto_disabled(self):
         """Spike-and-slab should be auto-disabled in retrospective mode."""
         df, pre, post, _ = _make_retrospective_data(
-            beta_persistent=3.0, with_covariate=True,
+            beta_persistent=3.0,
+            with_covariate=True,
         )
         ci = CausalImpact(
-            df, pre, post,
+            df,
+            pre,
+            post,
             model_args={
-                "niter": 200, "nwarmup": 100, "seed": 42,
-                "mode": "retrospective", "expected_model_size": 1,
+                "niter": 200,
+                "nwarmup": 100,
+                "seed": 42,
+                "mode": "retrospective",
+                "expected_model_size": 1,
             },
         )
         # Should have run without error; gamma should be empty or all-True
@@ -207,14 +254,23 @@ class TestRetrospectiveCausalImpact:
     def test_with_covariate(self):
         """Retrospective with an additional covariate should still work."""
         df, pre, post, _ = _make_retrospective_data(
-            beta_persistent=5.0, with_covariate=True,
-            noise_sd=0.5, seed=42, t_pre=200, t_post=50,
+            beta_persistent=5.0,
+            with_covariate=True,
+            noise_sd=0.5,
+            seed=42,
+            t_pre=200,
+            t_post=50,
         )
         ci = CausalImpact(
-            df, pre, post,
+            df,
+            pre,
+            post,
             model_args={
-                "niter": 2000, "nwarmup": 1000, "seed": 42,
-                "mode": "retrospective", "prior_level_sd": 0.001,
+                "niter": 2000,
+                "nwarmup": 1000,
+                "seed": 42,
+                "mode": "retrospective",
+                "prior_level_sd": 0.001,
             },
         )
         dec = ci._decomposition
@@ -238,20 +294,34 @@ class TestRetrospectiveCausalImpact:
         y = np.cumsum(rng.normal(0, 1, n)) + 100
         y[100:] += 5.0
         df = pd.DataFrame({"y": y})
-        ci = CausalImpact(df, [0, 99], [100, 129], model_args={"niter": 100, "nwarmup": 50})
+        ci = CausalImpact(
+            df,
+            [0, 99],
+            [100, 129],
+            model_args={"niter": 100, "nwarmup": 50},
+        )
         assert ci._decomposition is None
         assert hasattr(ci, "decompose")
 
     def test_decompose_returns_cached_in_retrospective(self):
         """decompose() should return the cached decomposition in retrospective mode."""
         df, pre, post, _ = _make_retrospective_data(
-            beta_persistent=3.0, noise_sd=0.5, seed=42, t_pre=100, t_post=30,
+            beta_persistent=3.0,
+            noise_sd=0.5,
+            seed=42,
+            t_pre=100,
+            t_post=30,
         )
         ci = CausalImpact(
-            df, pre, post,
+            df,
+            pre,
+            post,
             model_args={
-                "niter": 200, "nwarmup": 100, "seed": 42,
-                "mode": "retrospective", "prior_level_sd": 0.001,
+                "niter": 200,
+                "nwarmup": 100,
+                "seed": 42,
+                "mode": "retrospective",
+                "prior_level_sd": 0.001,
             },
         )
         # decompose() should work without crashing
@@ -262,13 +332,22 @@ class TestRetrospectiveCausalImpact:
     def test_decompose_recomputes_with_different_alpha(self):
         """decompose(alpha=0.1) should recompute with new credible intervals."""
         df, pre, post, _ = _make_retrospective_data(
-            beta_persistent=3.0, noise_sd=0.5, seed=42, t_pre=100, t_post=30,
+            beta_persistent=3.0,
+            noise_sd=0.5,
+            seed=42,
+            t_pre=100,
+            t_post=30,
         )
         ci = CausalImpact(
-            df, pre, post,
+            df,
+            pre,
+            post,
             model_args={
-                "niter": 200, "nwarmup": 100, "seed": 42,
-                "mode": "retrospective", "prior_level_sd": 0.001,
+                "niter": 200,
+                "nwarmup": 100,
+                "seed": 42,
+                "mode": "retrospective",
+                "prior_level_sd": 0.001,
             },
         )
         dec_05 = ci.decompose(alpha=0.05)
@@ -282,13 +361,22 @@ class TestRetrospectiveCausalImpact:
     def test_short_post_period_no_crash(self):
         """Retrospective with t_post=2 should not crash (trend=None)."""
         df, pre, post, _ = _make_retrospective_data(
-            beta_persistent=3.0, noise_sd=0.5, seed=42, t_pre=50, t_post=2,
+            beta_persistent=3.0,
+            noise_sd=0.5,
+            seed=42,
+            t_pre=50,
+            t_post=2,
         )
         ci = CausalImpact(
-            df, pre, post,
+            df,
+            pre,
+            post,
             model_args={
-                "niter": 100, "nwarmup": 50, "seed": 42,
-                "mode": "retrospective", "prior_level_sd": 0.001,
+                "niter": 100,
+                "nwarmup": 50,
+                "seed": 42,
+                "mode": "retrospective",
+                "prior_level_sd": 0.001,
             },
         )
         dec = ci._decomposition
@@ -304,10 +392,14 @@ class TestRetrospectiveCausalImpact:
         df = pd.DataFrame({"y": y})
         with pytest.raises(ValueError, match="dynamic_regression"):
             CausalImpact(
-                df, [0, 29], [30, 49],
+                df,
+                [0, 29],
+                [30, 49],
                 model_args={
-                    "niter": 100, "nwarmup": 50,
-                    "mode": "retrospective", "dynamic_regression": True,
+                    "niter": 100,
+                    "nwarmup": 50,
+                    "mode": "retrospective",
+                    "dynamic_regression": True,
                 },
             )
 
@@ -317,6 +409,8 @@ class TestRetrospectiveCausalImpact:
         df = pd.DataFrame({"y": y})
         with pytest.raises(ValueError, match="mode"):
             CausalImpact(
-                df, [0, 29], [30, 49],
+                df,
+                [0, 29],
+                [30, 49],
                 model_args={"niter": 100, "nwarmup": 50, "mode": "invalid"},
             )

--- a/tests/test_rust_sampler.py
+++ b/tests/test_rust_sampler.py
@@ -268,12 +268,28 @@ class TestSamplerErrors:
     """Error case tests."""
 
     def test_sampler_pre_end_equals_T(self):
+        """pre_end == len(y) is valid for retrospective mode (no post-period)."""
         y = [1.0, 2.0, 3.0]
-        with pytest.raises(ValueError, match="post-period"):
+        result = run_gibbs_sampler(
+            y=y,
+            x=None,
+            pre_end=3,
+            niter=10,
+            nwarmup=5,
+            nchains=1,
+            seed=42,
+            prior_level_sd=0.01,
+        )
+        for pred in result.predictions:
+            assert len(pred) == 0
+
+    def test_sampler_pre_end_exceeds_T(self):
+        y = [1.0, 2.0, 3.0]
+        with pytest.raises(ValueError, match="pre_end must be <= length of y"):
             run_gibbs_sampler(
                 y=y,
                 x=None,
-                pre_end=3,
+                pre_end=4,
                 niter=10,
                 nwarmup=5,
                 nchains=1,

--- a/uv.lock
+++ b/uv.lock
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "bsts-causalimpact"
-version = "1.3.1"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
## Summary

- DATE decomposition (`ci.decompose()`): decomposes pointwise causal effects into spot/persistent/trend components via OLS projection on MCMC posteriors (arXiv:2602.00836)
- Retrospective attribution mode (`mode="retrospective"`): treatment indicator columns as covariates, effects extracted from beta posteriors
- "Beyond R" documentation section covering all Python-only extensions

## Changes

### New files
- `python/causal_impact/decomposition.py` — `EffectComponent`, `DateDecomposition`, `build_design_matrix`, `decompose_effects`
- `python/causal_impact/retrospective.py` — `build_treatment_design`, `extract_treatment_effects`
- `tests/test_decomposition.py` — 49 tests
- `tests/test_retrospective.py` — 20 tests
- `docs/theory.md` — mathematical background with LaTeX
- `docs/javascripts/mathjax.js` — MathJax config for mkdocs

### Modified files
- `python/causal_impact/main.py` — `decompose()` method, `_run_retrospective()`, mode validation, dynamic_regression guard
- `python/causal_impact/plot.py` — decomposition panel support
- `python/causal_impact/__init__.py` — export `DateDecomposition`, `EffectComponent`
- `src/sampler.rs` — allow `pre_end == len(y)` for retrospective mode
- `tests/test_rust_sampler.py` — updated boundary test
- README, api.md, examples.md, compatibility-matrix.md, mkdocs.yml, CHANGELOG.md

### Bug fixes included
- Fix double-scaling bug in retrospective mode (`treatment_X / y_sd` removed)
- Guard `decompose()` for retrospective fits (return cached or recompute from betas)
- Handle `t_post < 3` in retrospective mode (trend=None, no IndexError)
- Reject `dynamic_regression=True` in retrospective mode (ValueError instead of silent ignore)

## Test plan

- [x] `pytest tests/test_decomposition.py -v` — 49 tests pass
- [x] `pytest tests/test_retrospective.py -v` — 20 tests pass
- [x] `pytest tests/ -v --ignore=tests/test_docs_assets.py` — 368 passed, 12 skipped, 1 xfailed
- [x] `cargo test` — 150 Rust tests pass
- [x] `ruff check python/ && ruff format --check python/` — all clean
- [ ] CI passes → semantic release

## Post-merge

CIが通ったらセマンティックリリースを実行。`feat:` prefix により minor version bump (e.g. 1.6.0)。