### PR TITLE
feat: horseshoe prior for BSTS regression (Kohns & Bhattacharjee 2022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## [Unreleased]
+
+### Added
+
+- Horseshoe prior as alternative to spike-and-slab via `ModelOptions(prior_type='horseshoe')`
+  (Kohns & Bhattacharjee 2022, arXiv:2011.00938). Recommended for dense DGP settings
+  where many covariates have true effects.
+- `posterior_shrinkage` property: mean shrinkage factor kappa_j per covariate (horseshoe only).
+- `kappa_shrinkage` field in Rust sampler output for per-iteration shrinkage diagnostics.
+
+### Fixed
+
+- `sample_inv_gamma` no longer panics on non-finite parameters (e.g. extreme-scale
+  inputs with `standardize_data=False`). Returns a small positive fallback instead.
+- `_normalize_model_args` now rejects unknown dict keys (e.g. typo `prior_typee`
+  silently falling back to `spike_slab` is no longer possible).
+- `kappa()` diagnostic now uses the same floor as the precision diagonal for consistency.
+
 ## [1.6.0] - 2026-03-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Posterior prob. of a causal effect: 99.90%
 | Algorithm | Gibbs (bsts/C++) | Gibbs (Rust) | TFP-based | VI default / HMC | MLE (statsmodels) |
 | Dependencies | R, bsts | numpy, pandas, matplotlib | TF, TFP (3 GB+) | TF, TFP (3 GB+) | statsmodels |
 | Spike-and-slab | Yes | Yes | Unknown | No | No |
+| Horseshoe prior | No | Yes (`prior_type='horseshoe'`) | No | No | No |
 | Seasonal component | Yes | Yes (`nseasons`, `season_duration`) | Unknown | Yes (TFP STS) | No |
 | Dynamic regression | Yes | Yes (`dynamic_regression=True`) | Unknown | No | No |
 | R numerical test | Reference | ±1% CI-enforced + TOST/ROPE | Not published | Visual comparison (~8% diff) | Not tested |
@@ -205,6 +206,7 @@ Evidence per implementation (all verified from source code, not documentation cl
 | DATE decomposition | Extended | Decomposes effects into spot/persistent/trend (arXiv:2602.00836) |
 | Retrospective mode | Extended | Treatment indicators as covariates; effects from beta posteriors (arXiv:2602.00836) |
 | Placebo test | Extended | Null distribution from pre-period splits |
+| Horseshoe prior | Extended | Continuous shrinkage alternative to spike-and-slab (Kohns & Bhattacharjee 2022) |
 | Conformal inference | Extended | Distribution-free prediction intervals |
 | DTW control selection | Extended | Automatic covariate selection via Dynamic Time Warping |
 
@@ -223,6 +225,7 @@ Features that go beyond R's CausalImpact. These have no R equivalent.
 | Placebo test | `ci.run_placebo_test()` | Validates effect against null distribution from pre-period splits | |
 | Conformal inference | `ci.run_conformal_analysis()` | Distribution-free prediction intervals | Vovk et al. (2005) |
 | DTW control selection | `select_controls()` | Automatic covariate selection via Dynamic Time Warping | Sakoe & Chiba (1978) |
+| Horseshoe prior | `ModelOptions(prior_type='horseshoe')` | Continuous shrinkage alternative to spike-and-slab for dense DGP | Kohns & Bhattacharjee (2022), arXiv:2011.00938 |
 
 ## API
 
@@ -251,6 +254,7 @@ Features that go beyond R's CausalImpact. These have no R equivalent.
 | `season_duration` | `None` | Optional duration of each seasonal block; defaults to `1` when `nseasons` is set |
 | `dynamic_regression` | `False` | Enable time-varying regression coefficients (random-walk beta) |
 | `state_model` | `"local_level"` | `"local_level"` or `"local_linear_trend"` |
+| `prior_type` | `"spike_slab"` | `"spike_slab"` or `"horseshoe"` (continuous shrinkage for dense DGP) |
 | `mode` | `"forward"` | `"forward"` (counterfactual prediction) or `"retrospective"` (treatment indicators as covariates) |
 
 #### Methods and Properties
@@ -262,7 +266,8 @@ Features that go beyond R's CausalImpact. These have no R equivalent.
 | `plot(metrics=None)` | `Figure` | Matplotlib figure with original/pointwise/cumulative panels |
 | `inferences` | `DataFrame` | Per-timestep actuals, predictions, prediction s.d., and effect intervals |
 | `summary_stats` | `dict` | Aggregate statistics (effect mean, CI, p-value, etc.) |
-| `posterior_inclusion_probs` | `ndarray \| None` | Posterior inclusion probability per covariate |
+| `posterior_inclusion_probs` | `ndarray \| None` | Posterior inclusion probability per covariate (spike-and-slab only) |
+| `posterior_shrinkage` | `ndarray \| None` | Mean shrinkage factor per covariate (horseshoe only) |
 | `decompose(alpha=None)` | `DateDecomposition` | DATE decomposition into spot/persistent/trend components |
 | `run_placebo_test(...)` | `PlaceboTestResults` | Placebo test for effect validation |
 | `run_conformal_analysis(...)` | `ConformalResults` | Distribution-free conformal prediction intervals |

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,7 +35,8 @@ ci = CausalImpact(data, pre_period, post_period, model_args=None, alpha=0.05)
 |---|---|---|
 | `inferences` | `DataFrame` | Per-timestep actuals, predictions, prediction s.d., and effect intervals |
 | `summary_stats` | `dict` | Aggregate statistics (effect mean, CI, p-value, etc.) |
-| `posterior_inclusion_probs` | `ndarray \| None` | Posterior inclusion probability per covariate (requires covariates) |
+| `posterior_inclusion_probs` | `ndarray \| None` | Posterior inclusion probability per covariate (spike-and-slab only; returns `None` for horseshoe) |
+| `posterior_shrinkage` | `ndarray \| None` | Mean shrinkage factor kappa_j per covariate (horseshoe only; returns `None` for spike-and-slab). Values near 0 = weakly shrunk (included), near 1 = strongly shrunk. |
 
 ## `ModelOptions`
 
@@ -58,6 +59,7 @@ ci = CausalImpact(data, pre_period, post_period, model_args=opts)
 | `standardize_data` | `bool` | `True` | Standardize data before fitting |
 | `expected_model_size` | `int` | 2 | Expected number of active covariates for spike-and-slab prior |
 | `dynamic_regression` | `bool` | `False` | Enable time-varying regression coefficients |
+| `prior_type` | `str` | `"spike_slab"` | `"spike_slab"` (discrete variable selection) or `"horseshoe"` (continuous shrinkage). Horseshoe is recommended for dense DGP settings. |
 | `state_model` | `str` | `"local_level"` | `"local_level"` or `"local_linear_trend"` |
 | `mode` | `str` | `"forward"` | `"forward"` (counterfactual prediction) or `"retrospective"` (treatment indicators as covariates). Retrospective mode adds spot/persistent/trend columns to X and fits on the entire series. Effects are extracted from beta posteriors. |
 | `nseasons` | `int \| None` | `None` | Seasonal cycle count. `nseasons=1` is equivalent to no seasonal component. |
@@ -85,6 +87,54 @@ Returned by `ci._results`. A frozen dataclass containing all computed quantities
 | `predictions_sd` | `ndarray` | Posterior standard deviation of the counterfactual prediction |
 | `predictions_lower` | `ndarray` | Lower CI on counterfactual |
 | `predictions_upper` | `ndarray` | Upper CI on counterfactual |
+
+## Horseshoe Prior (alternative to spike-and-slab)
+
+CausalImpact supports the horseshoe prior (Carvalho, Polson & Scott 2010)
+applied to BSTS regression, following the formulation of
+Kohns & Bhattacharjee (2022) (arXiv:2011.00938).
+
+### When to use horseshoe
+
+| Scenario | Recommended prior |
+|---|---|
+| Few true covariates (sparse DGP) | `spike_slab` (default) |
+| Many true covariates (dense DGP) | `horseshoe` |
+
+### Usage
+
+```python
+from causal_impact import CausalImpact, ModelOptions
+
+ci = CausalImpact(
+    data, pre_period, post_period,
+    model_args=ModelOptions(prior_type='horseshoe'),
+)
+print(ci.posterior_shrinkage)   # mean(kappa_j), 0=included 1=shrunk
+# ci.posterior_inclusion_probs is None for horseshoe (spike-slab only)
+```
+
+### Shrinkage diagnostics
+
+| Property | prior_type | Meaning |
+|---|---|---|
+| `posterior_inclusion_probs` | `spike_slab` | E[gamma_j] — discrete inclusion probability |
+| `posterior_inclusion_probs` | `horseshoe` | `None` (not applicable) |
+| `posterior_shrinkage` | `horseshoe` | E[kappa_j] — continuous shrinkage factor kappa_j = 1/(1+lambda_j^2 * tau^2). Values close to 0 indicate the covariate is weakly shrunk (effectively included). |
+| `posterior_shrinkage` | `spike_slab` | `None` (not applicable) |
+
+### Incompatible combinations
+
+- `prior_type='horseshoe'` + `dynamic_regression=True` raises `ValueError`
+- `prior_type='horseshoe'` + `mode='retrospective'` raises `ValueError`
+
+### References
+
+- Kohns, D. & Bhattacharjee, A. (2022). Horseshoe Prior for Sparse Bayesian Structural Time Series. arXiv:2011.00938.
+- Makalic, E. & Schmidt, D.F. (2015). A simple sampler for the horseshoe estimator. IEEE Signal Processing Letters, 23(1), 179-182.
+- Carvalho, C.M., Polson, N.G. & Scott, J.G. (2010). The horseshoe estimator for sparse signals. Biometrika, 97(2), 465-480.
+
+---
 
 ## Beyond R Extensions
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -61,9 +61,21 @@ ci = CausalImpact(data, pre_period, post_period, model_args=opts)
 | `dynamic_regression` | `bool` | `False` | Enable time-varying regression coefficients |
 | `prior_type` | `str` | `"spike_slab"` | `"spike_slab"` (discrete variable selection) or `"horseshoe"` (continuous shrinkage). Horseshoe is recommended for dense DGP settings. |
 | `state_model` | `str` | `"local_level"` | `"local_level"` or `"local_linear_trend"` |
-| `mode` | `str` | `"forward"` | `"forward"` (counterfactual prediction) or `"retrospective"` (treatment indicators as covariates). Retrospective mode adds spot/persistent/trend columns to X and fits on the entire series. Effects are extracted from beta posteriors. |
 | `nseasons` | `int \| None` | `None` | Seasonal cycle count. `nseasons=1` is equivalent to no seasonal component. |
 | `season_duration` | `int \| None` | `None` | Duration of each seasonal block; defaults to 1 when `nseasons` is set. Requires `nseasons` to be set. |
+
+### Analysis Mode
+
+`mode` controls forward vs retrospective analysis. Pass via `model_args` dict (not `ModelOptions`).
+
+| Value | Description |
+|---|---|
+| `"forward"` (default) | Counterfactual prediction: fit on pre-period, predict post-period |
+| `"retrospective"` | Treatment indicators as covariates: fit on entire series |
+
+```python
+ci = CausalImpact(data, pre, post, model_args={"mode": "retrospective"})
+```
 
 ## `CausalImpactResults`
 

--- a/docs/theory.md
+++ b/docs/theory.md
@@ -328,6 +328,73 @@ print(ci.posterior_shrinkage)   # E[kappa_j] per covariate
 # posterior_inclusion_probs is None for horseshoe
 ```
 
+### Implementation decisions not specified in the papers
+
+The following design choices are not prescribed by the reference papers.
+Each choice is documented here with its rationale so that reviewers can
+evaluate them independently.
+
+#### tau0 initialization
+
+The global shrinkage parameter tau^2 requires an initial value for the
+Gibbs sampler.  None of the three reference papers specify a concrete
+formula.  This implementation uses a data-adaptive heuristic:
+
+```
+y_norm = ||y_pre||_2 / sqrt(T_pre)
+tau0   = y_sd / (sqrt(k) * y_norm)
+tau^2_init = tau0^2
+```
+
+Rationale: after standardization y_sd is approximately 1.  Dividing by
+sqrt(k) prevents the global scale from growing with the number of
+covariates.  Dividing by y_norm anchors the prior scale to the signal
+magnitude.  Because tau^2 is resampled at every Gibbs iteration, the
+chain forgets the initial value within the warmup period.  If y_norm
+is near zero (constant y), tau0 falls back to 1.0 so that the prior
+remains diffuse.
+
+#### Numerical clamping on derived precision (not on raw draws)
+
+Raw InvGamma draws for lambda_j^2 and tau^2 receive no floor.  Clamping
+raw draws would distort the posterior distribution.  Instead, the derived
+precision diagonal entry is clamped:
+
+```
+lambda_tau_prod = max(lambda_j^2 * tau^2, 1e-30)   -- prevents 0-division
+prior_prec      = min(1 / lambda_tau_prod, 1e12)    -- prevents inf diagonal
+```
+
+This approach keeps the posterior intact while protecting the Cholesky
+decomposition from numerical failure.  The kappa() diagnostic uses the
+same 1e-30 floor so that shrinkage values stay consistent with the
+precision matrix actually used in the beta update.
+
+The fallback in sample_inv_gamma (returning 1e-30 for non-finite
+parameters) serves as a last-resort guard.  It triggers only under
+extreme-scale inputs (e.g. standardize_data=False with y of order 1e200)
+where the scale parameter overflows to infinity.
+
+#### Gibbs sampling order
+
+Horseshoe and spike-and-slab use different orderings within the Gibbs loop:
+
+```
+Horseshoe:   state -> beta (joint)   -> lambda2/nu -> tau2/xi -> sigma2_obs
+Spike-slab:  state -> sigma2_obs     -> beta (coordinate-wise)
+```
+
+Horseshoe samples beta jointly via a precision matrix conditioned on the
+current sigma2_obs.  After the joint beta update, sigma2_obs is resampled
+conditioned on the updated residual.  This follows Algorithm 1 of Makalic
+& Schmidt (2015) where the regression step precedes the variance update.
+
+Spike-and-slab samples sigma2_obs first because its coordinate-wise
+variable selection (gamma_j) is sensitive to cold-start: sampling beta
+with an uninformative sigma2_obs on the first iteration can cause the
+sampler to exclude all covariates.  Sampling sigma2_obs first gives beta
+a reasonable scale to condition on.
+
 ### References
 
 - Carvalho, C.M., Polson, N.G. & Scott, J.G. (2010). The horseshoe estimator

--- a/docs/theory.md
+++ b/docs/theory.md
@@ -10,6 +10,7 @@ Five additional capabilities extend the analysis beyond what R offers.
 | Placebo test | `ci.run_placebo_test()` | Validate effects against null distribution |
 | Conformal inference | `ci.run_conformal_analysis()` | Distribution-free prediction intervals |
 | DTW control selection | `select_controls()` | Automatic covariate selection |
+| Horseshoe prior | `ModelOptions(prior_type='horseshoe')` | Continuous shrinkage for dense DGP |
 
 ---
 
@@ -242,6 +243,99 @@ ci = CausalImpact(analysis_data, pre_period, post_period)
 
 Reference: Sakoe & Chiba (1978), "Dynamic programming algorithm optimization
 for spoken word recognition."
+
+---
+
+## Horseshoe Prior
+
+### What it does
+
+The horseshoe prior (Carvalho, Polson & Scott 2010) is a continuous shrinkage
+alternative to spike-and-slab variable selection. While spike-and-slab performs
+discrete inclusion/exclusion of covariates (gamma_j in {0,1}), the horseshoe
+applies adaptive shrinkage that can handle dense DGP settings where many
+covariates have true effects.
+
+Reference: Kohns & Bhattacharjee (2022), "Horseshoe Prior for Sparse Bayesian
+Structural Time Series" (arXiv:2011.00938).
+
+### Hierarchical model
+
+The horseshoe hierarchy uses Half-Cauchy priors decomposed into InvGamma
+auxiliary variables (Makalic & Schmidt 2015):
+
+```
+beta_j | lambda_j, tau, sigma2  ~ N(0, lambda_j^2 * tau^2 * sigma2_obs)
+lambda_j^2 | nu_j               ~ InvGamma(1/2, 1/nu_j)
+nu_j                             ~ InvGamma(1/2, 1)
+tau^2 | xi                       ~ InvGamma(1/2, 1/xi)
+xi                               ~ InvGamma(1/2, 1)
+```
+
+The conditional posteriors used in the Gibbs sampler:
+
+```
+lambda_j^2 | .  ~ InvGamma(1,       1/nu_j + beta_j^2 / (2 * tau^2 * sigma2))
+nu_j       | .  ~ InvGamma(1,       1 + 1/lambda_j^2)
+tau^2      | .  ~ InvGamma((k+1)/2, 1/xi + sum(beta_j^2 / (2 * lambda_j^2 * sigma2)))
+xi         | .  ~ InvGamma(1,       1 + 1/tau^2)
+```
+
+### Beta joint update
+
+Unlike spike-and-slab (coordinate-wise), horseshoe uses a joint beta update:
+
+```
+A = X'X + diag(1 / (lambda_j^2 * tau^2))    (precision matrix)
+b = X'(y - state - seasonal)                 (right-hand side)
+beta ~ N(A^{-1} b, sigma2_obs * A^{-1})     (sampled via Cholesky)
+```
+
+### Shrinkage factor
+
+The shrinkage factor kappa_j measures how much each covariate is shrunk:
+
+```
+kappa_j = 1 / (1 + lambda_j^2 * tau^2)
+```
+
+- kappa_j close to 1: strong shrinkage (covariate effectively excluded)
+- kappa_j close to 0: weak shrinkage (covariate effectively included)
+
+The `posterior_shrinkage` property returns E[kappa_j] averaged over post-warmup
+MCMC iterations.
+
+### When to use
+
+| Scenario | Recommended prior |
+|---|---|
+| Few true covariates among many candidates (sparse DGP) | `spike_slab` (default) |
+| Many covariates with true effects (dense DGP) | `horseshoe` |
+| Time-varying coefficients | `spike_slab` (horseshoe + dynamic_regression not supported) |
+
+### Usage
+
+```python
+from causal_impact import CausalImpact, ModelOptions
+
+ci = CausalImpact(
+    data, pre_period, post_period,
+    model_args=ModelOptions(prior_type='horseshoe', niter=2000, seed=42),
+)
+
+# Shrinkage diagnostics
+print(ci.posterior_shrinkage)   # E[kappa_j] per covariate
+# posterior_inclusion_probs is None for horseshoe
+```
+
+### References
+
+- Carvalho, C.M., Polson, N.G. & Scott, J.G. (2010). The horseshoe estimator
+  for sparse signals. Biometrika, 97(2), 465-480.
+- Kohns, D. & Bhattacharjee, A. (2022). Horseshoe Prior for Sparse Bayesian
+  Structural Time Series. arXiv:2011.00938.
+- Makalic, E. & Schmidt, D.F. (2015). A simple sampler for the horseshoe
+  estimator. IEEE Signal Processing Letters, 23(1), 179-182.
 
 ---
 

--- a/python/causal_impact/main.py
+++ b/python/causal_impact/main.py
@@ -34,6 +34,7 @@ DEFAULT_MODEL_ARGS = {
     "expected_model_size": 2,
     "dynamic_regression": False,
     "state_model": "local_level",
+    "prior_type": "spike_slab",
     "nseasons": None,
     "season_duration": None,
 }
@@ -43,25 +44,32 @@ def _normalize_model_args(
     model_args: dict | ModelOptions | None,
 ) -> dict:
     if isinstance(model_args, ModelOptions):
-        args = model_args.to_dict()
-    else:
-        args = dict(model_args or {})
+        return model_args.to_dict()
 
-    if "season.duration" in args:
-        if "season_duration" in args:
+    raw = dict(model_args or {})
+
+    if "season.duration" in raw:
+        if "season_duration" in raw:
             msg = "Use either season.duration or season_duration, not both"
             raise ValueError(msg)
-        args["season_duration"] = args.pop("season.duration")
+        raw["season_duration"] = raw.pop("season.duration")
 
-    normalized = {**DEFAULT_MODEL_ARGS, **args}
-    if normalized["state_model"] not in {"local_level", "local_linear_trend"}:
-        msg = (
-            "state_model must be one of "
-            "{'local_level', 'local_linear_trend'}, "
-            f"got {normalized['state_model']}"
-        )
-        raise ValueError(msg)
-    return normalized
+    # mode は ModelOptions のフィールドではないため先に抽出する
+    mode = raw.pop("mode", None)
+
+    _allowed = set(DEFAULT_MODEL_ARGS)
+    unknown = set(raw) - _allowed
+    if unknown:
+        raise ValueError(f"Unknown model_args keys: {sorted(unknown)}")
+
+    # ModelOptions を経由することで __post_init__ のバリデーションを全て通す
+    merged = {**DEFAULT_MODEL_ARGS, **raw}
+    opts = ModelOptions(**merged)
+
+    result = opts.to_dict()
+    if mode is not None:
+        result["mode"] = mode
+    return result
 
 
 class CausalImpact:
@@ -93,6 +101,12 @@ class CausalImpact:
             msg = (
                 "dynamic_regression is not supported in retrospective mode. "
                 "Use mode='forward' for time-varying coefficients."
+            )
+            raise ValueError(msg)
+        if mode == "retrospective" and args.get("prior_type") == "horseshoe":
+            msg = (
+                "horseshoe prior is not supported in retrospective mode. "
+                "Use prior_type='spike_slab' or mode='forward'."
             )
             raise ValueError(msg)
 
@@ -143,6 +157,7 @@ class CausalImpact:
             season_duration=args["season_duration"],
             dynamic_regression=bool(args.get("dynamic_regression", False)),
             state_model=str(args["state_model"]),
+            prior_type=str(args.get("prior_type", "spike_slab")),
         )
 
     def _run_retrospective(self, prepared: PreparedData, args: dict):
@@ -295,12 +310,32 @@ class CausalImpact:
     def posterior_inclusion_probs(self) -> np.ndarray | None:
         """Posterior inclusion probabilities for each covariate.
 
-        Returns None when there are no covariates (k=0).
+        Only available for prior_type='spike_slab'. Returns None for
+        horseshoe prior or when there are no covariates (k=0).
         """
+        if self._model_args.get("prior_type", "spike_slab") == "horseshoe":
+            return None
         gamma = self._samples.gamma
         if not gamma or not gamma[0]:
             return None
         return np.array(gamma).mean(axis=0)
+
+    @property
+    def posterior_shrinkage(self) -> np.ndarray | None:
+        """Mean shrinkage factor per covariate (horseshoe prior only).
+
+        kappa_j = E[1 / (1 + lambda_j^2 * tau^2)].
+        Values close to 1 indicate strong shrinkage (covariate excluded).
+        Values close to 0 indicate weak shrinkage (covariate included).
+
+        Returns None for spike_slab prior or when there are no covariates.
+        """
+        if self._model_args.get("prior_type", "spike_slab") != "horseshoe":
+            return None
+        kappa = self._samples.kappa_shrinkage
+        if not kappa or not kappa[0]:
+            return None
+        return np.array(kappa).mean(axis=0)
 
     @property
     def summary_stats(self) -> dict:

--- a/python/causal_impact/options.py
+++ b/python/causal_impact/options.py
@@ -21,10 +21,23 @@ class ModelOptions:
     expected_model_size: int = 2
     dynamic_regression: bool = False
     state_model: str = "local_level"
+    prior_type: str = "spike_slab"
     nseasons: int | None = None
     season_duration: int | None = None
 
     def __post_init__(self) -> None:
+        if self.prior_type not in {"spike_slab", "horseshoe"}:
+            msg = (
+                "prior_type must be 'spike_slab' or 'horseshoe', "
+                f"got {self.prior_type!r}"
+            )
+            raise ValueError(msg)
+        if self.prior_type == "horseshoe" and self.dynamic_regression:
+            msg = (
+                "horseshoe prior is not supported with dynamic_regression=True. "
+                "Use prior_type='spike_slab' for time-varying coefficients."
+            )
+            raise ValueError(msg)
         if self.niter < 1:
             msg = f"niter must be >= 1, got {self.niter}"
             raise ValueError(msg)

--- a/src/distributions.rs
+++ b/src/distributions.rs
@@ -4,8 +4,21 @@ use rand::Rng;
 use rand_distr::{Gamma, StandardNormal};
 
 pub fn sample_inv_gamma<R: Rng>(rng: &mut R, shape: f64, scale: f64) -> f64 {
-    let gamma = Gamma::new(shape, 1.0 / scale).expect("Invalid Gamma parameters");
+    // Guard against non-finite or non-positive parameters.
+    // When scale → inf (e.g. from extreme-scale horseshoe updates),
+    // IG(shape, inf) concentrates at 0; return a small positive value.
+    if !shape.is_finite() || shape <= 0.0 || !scale.is_finite() || scale <= 0.0 {
+        return 1e-30;
+    }
+    let rate = 1.0 / scale;
+    if !rate.is_finite() || rate <= 0.0 {
+        return 1e-30;
+    }
+    let gamma = Gamma::new(shape, rate).expect("Invalid Gamma parameters");
     let x: f64 = rng.sample(gamma);
+    if !x.is_finite() || x <= 0.0 {
+        return 1e-30;
+    }
     1.0 / x
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,19 @@ fn run_gibbs_sampler(
     let y_values = extract_series(y)?;
     let y_slice = y_values.as_slice()?;
     let x_vecs = extract_covariates(x)?;
+    if !x_vecs.is_empty() {
+        let t = y_slice.len();
+        for (i, col) in x_vecs.iter().enumerate() {
+            if col.len() != t {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "covariate column {} has length {} but y has length {}",
+                    i,
+                    col.len(),
+                    t
+                )));
+            }
+        }
+    }
     let prior = sampler::PriorType::from_str(prior_type)
         .map_err(pyo3::exceptions::PyValueError::new_err)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub struct GibbsSamples {
     pub gamma: Vec<Vec<bool>>,
     #[pyo3(get)]
     pub predictions: Vec<Vec<f64>>,
+    #[pyo3(get)]
+    pub kappa_shrinkage: Vec<Vec<f64>>,
 }
 
 #[pyfunction]
@@ -45,7 +47,8 @@ pub struct GibbsSamples {
         nseasons=None,
         season_duration=None,
         dynamic_regression=false,
-        state_model="local_level"
+        state_model="local_level",
+        prior_type="spike_slab"
     )
 )]
 #[allow(clippy::too_many_arguments)]
@@ -63,10 +66,13 @@ fn run_gibbs_sampler(
     season_duration: Option<f64>,
     dynamic_regression: bool,
     state_model: &str,
+    prior_type: &str,
 ) -> PyResult<GibbsSamples> {
     let y_values = extract_series(y)?;
     let y_slice = y_values.as_slice()?;
     let x_vecs = extract_covariates(x)?;
+    let prior = sampler::PriorType::from_str(prior_type)
+        .map_err(pyo3::exceptions::PyValueError::new_err)?;
 
     let result = sampler::run_sampler(
         y_slice,
@@ -82,6 +88,7 @@ fn run_gibbs_sampler(
         season_duration,
         dynamic_regression,
         state_model,
+        prior,
     )
     .map_err(pyo3::exceptions::PyValueError::new_err)?;
 
@@ -93,6 +100,7 @@ fn run_gibbs_sampler(
         beta: result.beta,
         gamma: result.gamma,
         predictions: result.predictions,
+        kappa_shrinkage: result.kappa_shrinkage,
     })
 }
 

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -16,6 +16,53 @@ const STATIC_REGRESSION_PRIOR_INFORMATION_WEIGHT: f64 = 0.01;
 const STATIC_REGRESSION_DIAGONAL_SHRINKAGE: f64 = 0.5;
 const LOCAL_LINEAR_TREND_SLOPE_SD_RATIO: f64 = 0.1;
 
+#[derive(Clone, Copy, PartialEq)]
+pub enum PriorType {
+    SpikeSlab,
+    Horseshoe,
+}
+
+impl PriorType {
+    pub fn from_str(s: &str) -> Result<Self, String> {
+        match s {
+            "spike_slab" => Ok(PriorType::SpikeSlab),
+            "horseshoe" => Ok(PriorType::Horseshoe),
+            _ => Err(format!(
+                "prior_type must be 'spike_slab' or 'horseshoe', got '{s}'"
+            )),
+        }
+    }
+}
+
+struct HorseshoeState {
+    tau2: f64,
+    xi: f64,
+    lambda2: Vec<f64>,
+    nu: Vec<f64>,
+}
+
+impl HorseshoeState {
+    fn new(k: usize, tau0_sq: f64) -> Self {
+        HorseshoeState {
+            tau2: tau0_sq,
+            xi: 1.0,
+            lambda2: vec![1.0; k],
+            nu: vec![1.0; k],
+        }
+    }
+
+    fn kappa(&self) -> Vec<f64> {
+        self.lambda2
+            .iter()
+            .map(|&l2| {
+                // Use same floor as precision diagonal to keep diagnostic consistent
+                let prod = (l2 * self.tau2).max(1e-30);
+                1.0 / (1.0 + prod)
+            })
+            .collect()
+    }
+}
+
 struct StaticRegressionPrior {
     beta_mean: Vec<f64>,
     beta_precision: Vec<Vec<f64>>,
@@ -32,6 +79,7 @@ struct ChainResult {
     beta: Vec<Vec<f64>>,
     gamma: Vec<Vec<bool>>,
     predictions: Vec<Vec<f64>>,
+    kappa_shrinkage: Vec<Vec<f64>>,
 }
 
 pub struct GibbsResult {
@@ -42,6 +90,7 @@ pub struct GibbsResult {
     pub beta: Vec<Vec<f64>>,
     pub gamma: Vec<Vec<bool>>,
     pub predictions: Vec<Vec<f64>>,
+    pub kappa_shrinkage: Vec<Vec<f64>>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -59,12 +108,18 @@ pub fn run_sampler(
     season_duration: Option<f64>,
     dynamic_regression: bool,
     state_model: &str,
+    prior_type: PriorType,
 ) -> Result<GibbsResult, String> {
     validate_inputs(y, pre_end, nchains)?;
 
     let k = x.len();
-    if k > 0 && expected_model_size <= 0.0 && !dynamic_regression {
+    if k > 0 && expected_model_size <= 0.0 && !dynamic_regression && prior_type == PriorType::SpikeSlab {
         return Err("expected_model_size must be > 0 when covariates are present".to_string());
+    }
+    if dynamic_regression && prior_type == PriorType::Horseshoe {
+        return Err(
+            "horseshoe prior is not supported with dynamic_regression=True".to_string(),
+        );
     }
 
     let seasonal = SeasonalConfig::from_optional(nseasons, season_duration)?;
@@ -86,6 +141,7 @@ pub fn run_sampler(
                 expected_model_size,
                 dynamic_regression,
                 state_model,
+                prior_type,
             )
         })
         .collect();
@@ -129,6 +185,7 @@ fn run_single_chain(
     expected_model_size: f64,
     dynamic_regression: bool,
     state_model: StateModel,
+    prior_type: PriorType,
 ) -> ChainResult {
     if dynamic_regression {
         run_single_chain_dynamic(
@@ -154,6 +211,7 @@ fn run_single_chain(
             chain_id,
             expected_model_size,
             state_model,
+            prior_type,
         )
     }
 }
@@ -205,6 +263,7 @@ fn run_single_chain_dynamic(
         beta: Vec::with_capacity(niter),
         gamma: Vec::with_capacity(0), // spike-and-slab disabled
         predictions: Vec::with_capacity(niter),
+        kappa_shrinkage: Vec::with_capacity(0), // horseshoe disabled in dynamic
     };
     let mut adjusted = vec![0.0; pre_end];
     let mut beta_targets = vec![0.0; pre_end];
@@ -379,6 +438,7 @@ fn run_single_chain_static(
     chain_id: usize,
     expected_model_size: f64,
     state_model: StateModel,
+    prior_type: PriorType,
 ) -> ChainResult {
     let t_total = y.len();
     let k = model.num_covariates();
@@ -413,6 +473,8 @@ fn run_single_chain_static(
         0
     };
 
+    let use_horseshoe = k > 0 && prior_type == PriorType::Horseshoe;
+
     let mut chain_result = ChainResult {
         chain_id,
         states: Vec::with_capacity(niter),
@@ -420,23 +482,43 @@ fn run_single_chain_static(
         sigma_level: Vec::with_capacity(niter),
         sigma_seasonal: Vec::with_capacity(if use_state_seasonal { niter } else { 0 }),
         beta: Vec::with_capacity(niter),
-        gamma: Vec::with_capacity(niter),
+        gamma: Vec::with_capacity(if use_horseshoe { 0 } else { niter }),
         predictions: Vec::with_capacity(niter),
+        kappa_shrinkage: Vec::with_capacity(if use_horseshoe { niter } else { 0 }),
     };
 
-    // Compute pi and log_prior_odds once
-    let pi = if k > 0 {
+    // Compute pi and log_prior_odds once (spike-and-slab only)
+    let pi = if k > 0 && !use_horseshoe {
         (expected_model_size / k as f64).min(1.0)
     } else {
         1.0
     };
-    let use_spike_slab = k > 0 && pi < 1.0;
+    let use_spike_slab = k > 0 && pi < 1.0 && !use_horseshoe;
     let log_prior_odds = if use_spike_slab {
         (pi / (1.0 - pi)).ln()
     } else {
         0.0
     };
     let g = pre_end as f64; // Zellner's g-prior parameter
+
+    // Horseshoe state initialization
+    let xtx_cache = if use_horseshoe {
+        Some(cross_product_matrix(model.covariates(), pre_end))
+    } else {
+        None
+    };
+    // heuristic init: tau0 = y_sd / (sqrt(k) * y_norm)
+    let mut hs = if use_horseshoe {
+        let y_norm = (y[..pre_end].iter().map(|v| v * v).sum::<f64>() / pre_end as f64).sqrt();
+        let tau0 = if y_norm > 1e-12 {
+            y_sd / ((k as f64).sqrt() * y_norm)
+        } else {
+            1.0
+        };
+        Some(HorseshoeState::new(k, tau0 * tau0))
+    } else {
+        None
+    };
 
     // Storage for seasonal state propagation
     let mut seasonal_state: Vec<f64> = vec![0.0; nseasons];
@@ -472,8 +554,45 @@ fn run_single_chain_static(
             s1_obs_pre = s1_obs;
 
             // Step 2: beta sampling (covariates only, no seasonal regressors)
+            // Horseshoe Gibbs order: state → beta (joint) → lambda2/nu → tau2/xi → sigma2_obs
+            // Spike-slab Gibbs order: state → sigma2_obs → beta (coordinate-wise)
+            // Horseshoe samples beta jointly via precision, so sigma2_obs must follow beta
+            // to condition on the updated residual. Spike-slab samples sigma2_obs first to
+            // avoid cold-start issues with coordinate-wise selection (see MEMORY.md).
             if k > 0 {
-                if use_spike_slab {
+                if use_horseshoe {
+                    fill_state_and_seasonal_residual(
+                        &mut residual,
+                        &y[..pre_end],
+                        &states,
+                        &s1_obs_pre,
+                        model.covariates(),
+                        &beta,
+                    );
+
+                    sample_horseshoe(
+                        &mut rng,
+                        &mut beta,
+                        &mut residual,
+                        model.covariates(),
+                        xtx_cache.as_ref().unwrap(),
+                        k,
+                        pre_end,
+                        sigma2_obs,
+                        hs.as_mut().unwrap(),
+                    );
+
+                    sigma2_obs = sample_sigma2_obs_seasonal(
+                        &mut rng,
+                        &y[..pre_end],
+                        &states,
+                        &s1_obs_pre,
+                        model.covariates(),
+                        &beta,
+                        y_sd,
+                        0.01,
+                    );
+                } else if use_spike_slab {
                     sigma2_obs = sample_sigma2_obs_seasonal(
                         &mut rng,
                         &y[..pre_end],
@@ -611,7 +730,11 @@ fn run_single_chain_static(
                 chain_result.sigma_level.push(sigma2_level.sqrt());
                 chain_result.sigma_seasonal.push(sigma2_seasonal.sqrt());
                 chain_result.beta.push(beta.clone());
-                if k > 0 {
+                if use_horseshoe {
+                    chain_result
+                        .kappa_shrinkage
+                        .push(hs.as_ref().unwrap().kappa());
+                } else if k > 0 {
                     chain_result.gamma.push(gamma.clone());
                 }
                 chain_result.predictions.push(predictions);
@@ -632,7 +755,63 @@ fn run_single_chain_static(
             );
 
             // Step 2-3: (sigma2_obs, gamma, beta) sampling
-            if k > 0 && use_spike_slab {
+            // Horseshoe Gibbs order: state → beta (joint) → lambda2/nu → tau2/xi → sigma2_obs
+            // Spike-slab Gibbs order: state → sigma2_obs → beta (coordinate-wise)
+            // See seasonal path comment above for rationale on the ordering difference.
+            if use_horseshoe {
+                fill_user_residual(
+                    &mut residual,
+                    &y[..pre_end],
+                    &states,
+                    model,
+                    &beta,
+                    &seasonal_beta,
+                );
+
+                sample_horseshoe(
+                    &mut rng,
+                    &mut beta,
+                    &mut residual,
+                    model.covariates(),
+                    xtx_cache.as_ref().unwrap(),
+                    k,
+                    pre_end,
+                    sigma2_obs,
+                    hs.as_mut().unwrap(),
+                );
+
+                if k_seasonal > 0 {
+                    let prior = seasonal_regression_prior
+                        .as_ref()
+                        .expect("seasonal regression prior must exist");
+                    fill_baseline_from_state_and_block(
+                        &mut baseline,
+                        &states,
+                        model.covariates(),
+                        &beta,
+                    );
+                    seasonal_beta = sample_beta_with_normal_prior(
+                        &mut rng,
+                        &y[..pre_end],
+                        &baseline,
+                        model.seasonal_covariates(),
+                        sigma2_obs,
+                        &prior.beta_mean,
+                        &prior.beta_precision,
+                    );
+                }
+
+                sigma2_obs = sample_sigma2_obs(
+                    &mut rng,
+                    &y[..pre_end],
+                    &states,
+                    model,
+                    &beta,
+                    &seasonal_beta,
+                    y_sd,
+                    0.01,
+                );
+            } else if k > 0 && use_spike_slab {
                 sigma2_obs = sample_sigma2_obs(
                     &mut rng,
                     &y[..pre_end],
@@ -807,7 +986,11 @@ fn run_single_chain_static(
                 chain_result.sigma_obs.push(sigma2_obs.sqrt());
                 chain_result.sigma_level.push(sigma2_level.sqrt());
                 chain_result.beta.push(beta.clone());
-                if k > 0 {
+                if use_horseshoe {
+                    chain_result
+                        .kappa_shrinkage
+                        .push(hs.as_ref().unwrap().kappa());
+                } else if k > 0 {
                     chain_result.gamma.push(gamma.clone());
                 }
                 chain_result.predictions.push(predictions);
@@ -829,6 +1012,7 @@ fn flatten_chain_results(mut chain_results: Vec<ChainResult>, n_samples: usize) 
         beta: Vec::with_capacity(n_samples),
         gamma: Vec::with_capacity(n_samples),
         predictions: Vec::with_capacity(n_samples),
+        kappa_shrinkage: Vec::with_capacity(n_samples),
     };
 
     for chain_result in chain_results {
@@ -839,6 +1023,7 @@ fn flatten_chain_results(mut chain_results: Vec<ChainResult>, n_samples: usize) 
         result.beta.extend(chain_result.beta);
         result.gamma.extend(chain_result.gamma);
         result.predictions.extend(chain_result.predictions);
+        result.kappa_shrinkage.extend(chain_result.kappa_shrinkage);
     }
 
     result
@@ -1189,6 +1374,88 @@ fn sample_spike_and_slab<R: rand::Rng>(
             *r -= x_col[t] * beta[j];
         }
     }
+}
+
+/// Horseshoe prior sampling (Makalic & Schmidt 2015 auxiliary variable scheme).
+///
+/// Joint update of beta via precision sampler, then per-coordinate
+/// updates of lambda2, nu, tau2, xi from InvGamma conditionals.
+#[allow(clippy::too_many_arguments)]
+fn sample_horseshoe<R: rand::Rng>(
+    rng: &mut R,
+    beta: &mut Vec<f64>,
+    residual: &mut [f64],
+    x: &[Vec<f64>],
+    xtx: &[Vec<f64>],
+    k: usize,
+    pre_end: usize,
+    sigma2_obs: f64,
+    hs: &mut HorseshoeState,
+) {
+    // 1. Build precision: A = X'X + diag(1 / (lambda2[j] * tau2))
+    let mut precision = vec![vec![0.0; k]; k];
+    for i in 0..k {
+        for j in 0..k {
+            precision[i][j] = xtx[i][j];
+        }
+        let lambda_tau_prod = (hs.lambda2[i] * hs.tau2).max(1e-30);
+        let prior_prec = (1.0 / lambda_tau_prod).min(1e12);
+        precision[i][i] += prior_prec;
+    }
+
+    // 2. Compute rhs = X'residual + X'X * beta (add back beta contribution)
+    let mut xtr = vec![0.0; k];
+    for (j, x_col) in x.iter().enumerate() {
+        let xtr_residual: f64 = x_col
+            .iter()
+            .zip(residual.iter())
+            .take(pre_end)
+            .map(|(x_val, r_val)| x_val * r_val)
+            .sum();
+        let xtx_beta: f64 = xtx[j]
+            .iter()
+            .zip(beta.iter())
+            .map(|(a, b)| a * b)
+            .sum();
+        xtr[j] = xtr_residual + xtx_beta;
+    }
+
+    // 3. Sample beta ~ N(A^{-1}b, sigma2_obs * A^{-1})
+    let new_beta = sample_from_precision(rng, &precision, &xtr, sigma2_obs);
+
+    // 4. Update residual with new beta
+    for (t, r) in residual.iter_mut().enumerate().take(pre_end) {
+        for (j, x_col) in x.iter().enumerate() {
+            *r += x_col[t] * beta[j] - x_col[t] * new_beta[j];
+        }
+    }
+    *beta = new_beta;
+
+    // 5. Per-coordinate: lambda2[j] ~ IG(1, 1/nu[j] + beta[j]^2 / (2*tau2*sigma2))
+    for j in 0..k {
+        let scale = 1.0 / hs.nu[j] + beta[j] * beta[j] / (2.0 * hs.tau2 * sigma2_obs);
+        hs.lambda2[j] = sample_inv_gamma(rng, 1.0, scale);
+    }
+
+    // 6. Per-coordinate: nu[j] ~ IG(1, 1 + 1/lambda2[j])
+    for j in 0..k {
+        let scale = 1.0 + 1.0 / hs.lambda2[j];
+        hs.nu[j] = sample_inv_gamma(rng, 1.0, scale);
+    }
+
+    // 7. Global: tau2 ~ IG((k+1)/2, 1/xi + sum(beta[j]^2 / (2*lambda2[j]*sigma2)))
+    let sum_beta2_over_lambda2: f64 = beta
+        .iter()
+        .zip(hs.lambda2.iter())
+        .map(|(&b, &l2)| b * b / (2.0 * l2 * sigma2_obs))
+        .sum();
+    let tau2_shape = (k as f64 + 1.0) / 2.0;
+    let tau2_scale = 1.0 / hs.xi + sum_beta2_over_lambda2;
+    hs.tau2 = sample_inv_gamma(rng, tau2_shape, tau2_scale);
+
+    // 8. Global: xi ~ IG(1, 1 + 1/tau2)
+    let xi_scale = 1.0 + 1.0 / hs.tau2;
+    hs.xi = sample_inv_gamma(rng, 1.0, xi_scale);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1629,6 +1896,7 @@ pub fn run_placebo_test(
     let y_pre = &y[..pre_end];
 
     // Compute real effect: run sampler on full y with real pre_end
+    // Placebo test always uses spike_slab prior
     let real_model = StateSpaceModel::new(y.len(), x.clone(), seasonal);
     let real_chain = run_single_chain(
         y,
@@ -1642,6 +1910,7 @@ pub fn run_placebo_test(
         expected_model_size,
         false, // static only for placebo
         state_model,
+        PriorType::SpikeSlab,
     );
     let real_effect_abs = compute_abs_average_effect(
         &y[pre_end..],
@@ -1682,6 +1951,7 @@ pub fn run_placebo_test(
                 expected_model_size,
                 false,
                 state_model,
+                PriorType::SpikeSlab,
             );
             compute_abs_average_effect(&y_pre[split..], &chain.predictions)
         })
@@ -1751,6 +2021,7 @@ mod tests {
             None,
             false,
             "local_level",
+            PriorType::SpikeSlab,
         )
         .unwrap();
         assert_eq!(result.states.len(), 10);
@@ -1778,6 +2049,7 @@ mod tests {
             None,
             false,
             "local_level",
+            PriorType::SpikeSlab,
         )
         .unwrap();
         assert_eq!(result.beta.len(), 10);
@@ -1802,6 +2074,7 @@ mod tests {
             None,
             false,
             "local_level",
+            PriorType::SpikeSlab,
         );
         assert!(result.is_err());
     }
@@ -1824,6 +2097,7 @@ mod tests {
             None,
             false,
             "local_level",
+            PriorType::SpikeSlab,
         );
         assert!(result.is_ok());
         let gibbs = result.unwrap();
@@ -1850,6 +2124,7 @@ mod tests {
             None,
             false,
             "local_level",
+            PriorType::SpikeSlab,
         );
         assert!(result.is_err());
     }
@@ -1873,6 +2148,7 @@ mod tests {
             None,
             false,
             "local_level",
+            PriorType::SpikeSlab,
         );
         assert!(result.is_err());
         // k>0 with negative should fail
@@ -1890,6 +2166,7 @@ mod tests {
             None,
             false,
             "local_level",
+            PriorType::SpikeSlab,
         );
         assert!(result.is_err());
     }
@@ -1951,6 +2228,7 @@ mod tests {
             None,
             true,
             "local_level",
+            PriorType::SpikeSlab,
         )
         .unwrap();
         assert_eq!(result.predictions.len(), 10);
@@ -1976,6 +2254,7 @@ mod tests {
             None,
             true,
             "local_level",
+            PriorType::SpikeSlab,
         )
         .unwrap();
         let result_static = run_sampler(
@@ -1992,6 +2271,7 @@ mod tests {
             None,
             false,
             "local_level",
+            PriorType::SpikeSlab,
         )
         .unwrap();
         // With k=0, both paths should produce identical predictions
@@ -2019,6 +2299,7 @@ mod tests {
             None,
             true,
             "local_level",
+            PriorType::SpikeSlab,
         )
         .unwrap();
         for pred_row in &result.predictions {
@@ -2045,6 +2326,7 @@ mod tests {
             None,
             false,
             "local_linear_trend",
+            PriorType::SpikeSlab,
         )
         .unwrap();
 

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -113,6 +113,19 @@ pub fn run_sampler(
     validate_inputs(y, pre_end, nchains)?;
 
     let k = x.len();
+    if k > 0 {
+        let t = y.len();
+        for (i, col) in x.iter().enumerate() {
+            if col.len() != t {
+                return Err(format!(
+                    "covariate column {} has length {} but y has length {}",
+                    i,
+                    col.len(),
+                    t
+                ));
+            }
+        }
+    }
     if k > 0 && expected_model_size <= 0.0 && !dynamic_regression && prior_type == PriorType::SpikeSlab {
         return Err("expected_model_size must be > 0 when covariates are present".to_string());
     }
@@ -507,7 +520,12 @@ fn run_single_chain_static(
     } else {
         None
     };
-    // heuristic init: tau0 = y_sd / (sqrt(k) * y_norm)
+    // Heuristic init for global shrinkage (not specified in Kohns 2022 or
+    // Makalic 2015). tau0 = y_sd / (sqrt(k) * y_norm) anchors the prior
+    // scale to signal magnitude, normalized by covariate count. After
+    // standardization y_sd ≈ 1, so tau0 ≈ 1/(sqrt(k) * y_norm). The chain
+    // forgets this initial value within the warmup period. Falls back to 1.0
+    // when y is near-constant (y_norm ≈ 0). See docs/theory.md for details.
     let mut hs = if use_horseshoe {
         let y_norm = (y[..pre_end].iter().map(|v| v * v).sum::<f64>() / pre_end as f64).sqrt();
         let tau0 = if y_norm > 1e-12 {
@@ -1393,6 +1411,10 @@ fn sample_horseshoe<R: rand::Rng>(
     hs: &mut HorseshoeState,
 ) {
     // 1. Build precision: A = X'X + diag(1 / (lambda2[j] * tau2))
+    // Clamp the derived precision diagonal, NOT the raw draws (lambda2, tau2).
+    // Clamping raw draws would distort the posterior. The floor 1e-30 prevents
+    // zero-division; the ceiling 1e12 prevents inf in the Cholesky input.
+    // kappa() uses the same 1e-30 floor to stay consistent with the actual A.
     let mut precision = vec![vec![0.0; k]; k];
     for i in 0..k {
         for j in 0..k {
@@ -2491,5 +2513,35 @@ mod tests {
         let val = sample_sigma2_seasonal(&mut rng, 0.0, 0, 1e-10, 1.0);
         assert!(val.is_finite(), "must be finite for tiny prior_level_sd");
         assert!(val > 0.0);
+    }
+
+    #[test]
+    fn test_run_sampler_rejects_covariate_length_mismatch() {
+        let y: Vec<f64> = (0..20).map(|i| 10.0 + 0.1 * i as f64).collect();
+        let x_short = vec![(0..10).map(|i| i as f64 * 0.1).collect()];
+        let result = run_sampler(
+            &y,
+            x_short,
+            15,
+            10,
+            5,
+            1,
+            42,
+            0.01,
+            1.0,
+            None,
+            None,
+            false,
+            "local_level",
+            PriorType::SpikeSlab,
+        );
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("expected Err but got Ok"),
+        };
+        assert!(
+            err.contains("covariate column 0 has length 10 but y has length 20"),
+            "unexpected error message: {err}"
+        );
     }
 }

--- a/tests/test_horseshoe.py
+++ b/tests/test_horseshoe.py
@@ -700,7 +700,7 @@ class TestHorseshoeDenseDGPComparison:
         assert mse_hs <= mse_ss * 1.5
 
     def test_horseshoe_dense_dgp_predictions_finite_and_within_3sd(self):
-        """Predictions on dense DGP (5 signal + 5 noise) should be finite and reasonable."""
+        """Dense DGP (5 signal + 5 noise): finite and reasonable."""
         y, x, pre_end = _make_data_k10_dense()
         samples = _run_sampler_with_horseshoe(
             y, x, pre_end, niter=500, nwarmup=250

--- a/tests/test_horseshoe.py
+++ b/tests/test_horseshoe.py
@@ -1,0 +1,774 @@
+"""Horseshoe prior specification tests.
+
+Each test name encodes: test_horseshoe_{condition}_{expected_outcome}
+These tests serve as the specification for the horseshoe prior feature.
+
+Reference: Kohns & Bhattacharjee (2022), arXiv:2011.00938
+           Makalic & Schmidt (2015), IEEE Signal Processing Letters 23(1).
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+from causal_impact import CausalImpact, ModelOptions
+from causal_impact._core import run_gibbs_sampler
+
+# ---------------------------------------------------------------------------
+# Fixtures: deterministic data generators
+# ---------------------------------------------------------------------------
+
+
+def _make_data_k1_strong(n=100, pre_frac=0.7, seed=42):
+    """k=1, x strongly correlated with y."""
+    rng = np.random.default_rng(seed)
+    pre_end = int(n * pre_frac)
+    x = rng.normal(5, 1, n)
+    y = 2.0 * x + rng.normal(0, 0.3, n)
+    return y.tolist(), [x.tolist()], pre_end
+
+
+def _make_data_k2_signal_noise(n=100, pre_frac=0.7, seed=42):
+    """k=2: x1 is signal (coeff=2.0), x2 is pure noise."""
+    rng = np.random.default_rng(seed)
+    pre_end = int(n * pre_frac)
+    x1 = rng.normal(5, 1, n)
+    x2 = rng.normal(0, 1, n)
+    y = 2.0 * x1 + rng.normal(0, 0.3, n)
+    return y.tolist(), [x1.tolist(), x2.tolist()], pre_end
+
+
+def _make_data_k3_all_noise(n=100, pre_frac=0.7, seed=42):
+    """k=3: all covariates are independent noise."""
+    rng = np.random.default_rng(seed)
+    pre_end = int(n * pre_frac)
+    x1 = rng.normal(0, 1, n)
+    x2 = rng.normal(0, 1, n)
+    x3 = rng.normal(0, 1, n)
+    y = np.cumsum(rng.normal(0, 0.1, n)) + 10.0
+    return y.tolist(), [x1.tolist(), x2.tolist(), x3.tolist()], pre_end
+
+
+def _make_data_k3_all_signal(n=100, pre_frac=0.7, seed=42):
+    """k=3: all covariates contribute to y (dense DGP)."""
+    rng = np.random.default_rng(seed)
+    pre_end = int(n * pre_frac)
+    x1 = rng.normal(5, 1, n)
+    x2 = rng.normal(3, 1, n)
+    x3 = rng.normal(1, 1, n)
+    y = 1.0 * x1 + 0.8 * x2 + 0.6 * x3 + rng.normal(0, 0.3, n)
+    return y.tolist(), [x1.tolist(), x2.tolist(), x3.tolist()], pre_end
+
+
+def _make_data_k10_dense(n=200, pre_frac=0.7, seed=42):
+    """k=10: 5 signal + 5 noise covariates (dense DGP)."""
+    rng = np.random.default_rng(seed)
+    pre_end = int(n * pre_frac)
+    xs = [rng.normal(0, 1, n) for _ in range(10)]
+    coeffs = [0.5, 0.4, 0.3, 0.2, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0]
+    y = sum(c * x for c, x in zip(coeffs, xs)) + rng.normal(0, 0.3, n)
+    return y.tolist(), [x.tolist() for x in xs], pre_end
+
+
+def _run_sampler_with_horseshoe(
+    y, x, pre_end, niter=200, nwarmup=100, seed=42, nchains=1
+):
+    """Helper to call run_gibbs_sampler with prior_type='horseshoe'."""
+    return run_gibbs_sampler(
+        y=y,
+        x=x if x else None,
+        pre_end=pre_end,
+        niter=niter,
+        nwarmup=nwarmup,
+        nchains=nchains,
+        seed=seed,
+        prior_level_sd=0.01,
+        expected_model_size=1.0,
+        prior_type="horseshoe",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Class 1: Output shape
+# ---------------------------------------------------------------------------
+
+
+class TestHorseshoeOutputShape:
+    """Verify output shapes and value ranges of kappa_shrinkage."""
+
+    def test_horseshoe_kappa_shrinkage_shape_is_niter_by_k(self):
+        """Given k=3 data, kappa_shrinkage has shape (niter, k)."""
+        y, x, pre_end = _make_data_k3_all_noise()
+        samples = _run_sampler_with_horseshoe(y, x, pre_end, niter=200)
+
+        kappa = np.array(samples.kappa_shrinkage)
+        assert kappa.shape == (200, 3)
+
+    def test_horseshoe_kappa_shrinkage_values_are_between_0_and_1_exclusive(self):
+        """Given k=3 data, all kappa values in (0, 1)."""
+        y, x, pre_end = _make_data_k3_all_noise()
+        samples = _run_sampler_with_horseshoe(y, x, pre_end, niter=200)
+
+        kappa = np.array(samples.kappa_shrinkage)
+        assert np.all(kappa > 0)
+        assert np.all(kappa < 1)
+
+    def test_horseshoe_beta_shape_matches_niter_by_k(self):
+        """Given k=2 data, beta has shape (niter, k)."""
+        y, x, pre_end = _make_data_k2_signal_noise()
+        samples = _run_sampler_with_horseshoe(y, x, pre_end, niter=200)
+
+        beta = np.array(samples.beta)
+        assert beta.shape == (200, 2)
+
+    def test_horseshoe_gamma_is_empty_list(self):
+        """Horseshoe does not use gamma (spike-and-slab disabled)."""
+        y, x, pre_end = _make_data_k2_signal_noise()
+        samples = _run_sampler_with_horseshoe(y, x, pre_end, niter=200)
+
+        assert samples.gamma == []
+
+    def test_horseshoe_predictions_shape_is_niter_by_post_length(self):
+        """Given n=100, pre_end=70, predictions shape = (niter, 30)."""
+        y, x, pre_end = _make_data_k1_strong(n=100)
+        samples = _run_sampler_with_horseshoe(y, x, pre_end, niter=200)
+
+        assert len(samples.predictions) == 200
+        assert len(samples.predictions[0]) == 30
+
+    def test_horseshoe_k1_kappa_shape_is_niter_by_1(self):
+        """Boundary: k=1 (minimum covariates)."""
+        y, x, pre_end = _make_data_k1_strong()
+        samples = _run_sampler_with_horseshoe(y, x, pre_end, niter=200)
+
+        kappa = np.array(samples.kappa_shrinkage)
+        assert kappa.shape == (200, 1)
+
+    def test_horseshoe_nchains_2_kappa_shape_is_double_niter_by_k(self):
+        """Boundary: nchains=2 doubles samples."""
+        y, x, pre_end = _make_data_k2_signal_noise()
+        samples = _run_sampler_with_horseshoe(
+            y, x, pre_end, niter=100, nchains=2
+        )
+
+        kappa = np.array(samples.kappa_shrinkage)
+        assert kappa.shape == (200, 2)
+
+
+# ---------------------------------------------------------------------------
+# Class 2: Shrinkage behavior
+# ---------------------------------------------------------------------------
+
+
+class TestHorseshoeShrinkageBehavior:
+    """Verify that horseshoe correctly shrinks noise and preserves signal."""
+
+    def test_horseshoe_signal_covariate_has_low_mean_kappa(self):
+        """Given k=2 with signal+noise, signal covariate has low kappa."""
+        y, x, pre_end = _make_data_k2_signal_noise()
+        samples = _run_sampler_with_horseshoe(
+            y, x, pre_end, niter=500, nwarmup=250
+        )
+
+        kappa = np.array(samples.kappa_shrinkage)
+        assert kappa[:, 0].mean() < 0.5
+
+    def test_horseshoe_noise_covariate_has_high_mean_kappa(self):
+        """Given k=2 with signal+noise, noise covariate has high kappa."""
+        y, x, pre_end = _make_data_k2_signal_noise()
+        samples = _run_sampler_with_horseshoe(
+            y, x, pre_end, niter=500, nwarmup=250
+        )
+
+        kappa = np.array(samples.kappa_shrinkage)
+        assert kappa[:, 1].mean() > 0.5
+
+    def test_horseshoe_k3_all_noise_all_kappa_above_threshold(self):
+        """Given k=3 all-noise DGP, all kappa should be above 0.3."""
+        y, x, pre_end = _make_data_k3_all_noise()
+        samples = _run_sampler_with_horseshoe(
+            y, x, pre_end, niter=500, nwarmup=250
+        )
+
+        kappa = np.array(samples.kappa_shrinkage)
+        for j in range(3):
+            assert kappa[:, j].mean() > 0.3
+
+    def test_horseshoe_k3_all_signal_all_kappa_below_threshold(self):
+        """Given k=3 all-signal DGP, all kappa should be below 0.7."""
+        y, x, pre_end = _make_data_k3_all_signal()
+        samples = _run_sampler_with_horseshoe(
+            y, x, pre_end, niter=500, nwarmup=250
+        )
+
+        kappa = np.array(samples.kappa_shrinkage)
+        for j in range(3):
+            assert kappa[:, j].mean() < 0.7
+
+    def test_horseshoe_k1_strong_signal_kappa_near_zero(self):
+        """Given k=1 strong signal (coeff=2.0), kappa should be near 0."""
+        y, x, pre_end = _make_data_k1_strong()
+        samples = _run_sampler_with_horseshoe(
+            y, x, pre_end, niter=500, nwarmup=250
+        )
+
+        kappa = np.array(samples.kappa_shrinkage)
+        assert kappa[:, 0].mean() < 0.3
+
+
+# ---------------------------------------------------------------------------
+# Class 3: Posterior shrinkage property
+# ---------------------------------------------------------------------------
+
+
+class TestHorseshoePosteriorShrinkage:
+    """Verify posterior_shrinkage property via Python API."""
+
+    def test_horseshoe_posterior_shrinkage_shape_is_k(self):
+        """posterior_shrinkage has shape (k,)."""
+        y, x, pre_end = _make_data_k3_all_noise()
+        samples = _run_sampler_with_horseshoe(y, x, pre_end)
+
+        kappa = np.array(samples.kappa_shrinkage)
+        shrinkage = kappa.mean(axis=0)
+        assert shrinkage.shape == (3,)
+
+    def test_horseshoe_posterior_shrinkage_values_between_0_and_1(self):
+        """All posterior_shrinkage values in [0, 1]."""
+        y, x, pre_end = _make_data_k3_all_noise()
+        samples = _run_sampler_with_horseshoe(y, x, pre_end)
+
+        kappa = np.array(samples.kappa_shrinkage)
+        shrinkage = kappa.mean(axis=0)
+        assert np.all(shrinkage >= 0)
+        assert np.all(shrinkage <= 1)
+
+    def test_horseshoe_posterior_shrinkage_signal_lower_than_noise(self):
+        """Signal covariate has lower shrinkage than noise."""
+        y, x, pre_end = _make_data_k2_signal_noise()
+        samples = _run_sampler_with_horseshoe(
+            y, x, pre_end, niter=500, nwarmup=250
+        )
+
+        kappa = np.array(samples.kappa_shrinkage)
+        shrinkage = kappa.mean(axis=0)
+        assert shrinkage[0] < shrinkage[1]
+
+
+# ---------------------------------------------------------------------------
+# Class 4: Positivity
+# ---------------------------------------------------------------------------
+
+
+class TestHorseshoePositivity:
+    """Verify variance parameters are positive via kappa output."""
+
+    def test_horseshoe_kappa_all_positive(self):
+        """All kappa values are strictly positive."""
+        y, x, pre_end = _make_data_k2_signal_noise()
+        samples = _run_sampler_with_horseshoe(y, x, pre_end, niter=200)
+
+        kappa = np.array(samples.kappa_shrinkage)
+        assert np.all(kappa > 0)
+
+    def test_horseshoe_kappa_all_less_than_one(self):
+        """All kappa values are strictly less than one."""
+        y, x, pre_end = _make_data_k2_signal_noise()
+        samples = _run_sampler_with_horseshoe(y, x, pre_end, niter=200)
+
+        kappa = np.array(samples.kappa_shrinkage)
+        assert np.all(kappa < 1)
+
+
+# ---------------------------------------------------------------------------
+# Class 5: Backward compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestHorseshoeBackwardCompat:
+    """Spike-and-slab behavior must be unchanged after horseshoe addition."""
+
+    def test_spike_slab_default_kappa_shrinkage_is_empty(self):
+        """Default (spike_slab) prior returns empty kappa_shrinkage."""
+        y, x, pre_end = _make_data_k2_signal_noise()
+        samples = run_gibbs_sampler(
+            y=y,
+            x=x,
+            pre_end=pre_end,
+            niter=200,
+            nwarmup=100,
+            nchains=1,
+            seed=42,
+            prior_level_sd=0.01,
+            expected_model_size=1.0,
+        )
+
+        assert samples.kappa_shrinkage == []
+
+    def test_spike_slab_default_gamma_unchanged_after_horseshoe_addition(self):
+        """Spike-and-slab gamma shape and type are preserved."""
+        y, x, pre_end = _make_data_k2_signal_noise()
+        samples = run_gibbs_sampler(
+            y=y,
+            x=x,
+            pre_end=pre_end,
+            niter=200,
+            nwarmup=100,
+            nchains=1,
+            seed=42,
+            prior_level_sd=0.01,
+            expected_model_size=1.0,
+        )
+
+        gamma = np.array(samples.gamma)
+        assert gamma.shape == (200, 2)
+        assert gamma.dtype == bool
+
+    def test_no_covariates_kappa_shrinkage_is_empty_regardless_of_prior_type(self):
+        """k=0 with horseshoe still returns empty kappa."""
+        y = np.cumsum(np.random.default_rng(42).normal(0, 0.1, 50)) + 10.0
+        samples = run_gibbs_sampler(
+            y=y.tolist(),
+            x=None,
+            pre_end=35,
+            niter=50,
+            nwarmup=25,
+            nchains=1,
+            seed=42,
+            prior_level_sd=0.01,
+            prior_type="horseshoe",
+        )
+
+        assert samples.kappa_shrinkage == []
+
+
+# ---------------------------------------------------------------------------
+# Class 6: Numerical stability
+# ---------------------------------------------------------------------------
+
+
+class TestHorseshoeNumericalStability:
+    """Edge cases that might cause numerical issues."""
+
+    def test_horseshoe_zero_variance_covariate_no_crash(self):
+        """Constant covariate should not crash."""
+        n = 50
+        y = [10.0 + 0.1 * i for i in range(n)]
+        x = [[5.0] * n]  # constant
+        samples = _run_sampler_with_horseshoe(y, x, 35, niter=50, nwarmup=25)
+
+        kappa = np.array(samples.kappa_shrinkage)
+        assert kappa.shape == (50, 1)
+        assert np.all(np.isfinite(kappa))
+
+    def test_horseshoe_near_zero_variance_covariate_no_crash(self):
+        """Near-constant covariate should not crash or produce NaN."""
+        n = 50
+        y = [10.0 + 0.1 * i for i in range(n)]
+        x = [[1.0 + 1e-15 * i for i in range(n)]]
+        samples = _run_sampler_with_horseshoe(y, x, 35, niter=50, nwarmup=25)
+
+        kappa = np.array(samples.kappa_shrinkage)
+        assert np.all(np.isfinite(kappa))
+
+    def test_horseshoe_pre_end_3_minimal_no_crash(self):
+        """Minimal pre_end=3 should not crash."""
+        y = [10.0, 10.5, 11.0, 11.5, 12.0, 12.5]
+        x = [[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]]
+        samples = _run_sampler_with_horseshoe(y, x, 3, niter=50, nwarmup=25)
+
+        assert len(samples.predictions) == 50
+
+    def test_horseshoe_large_k_10_no_crash(self):
+        """k=10 covariates should not crash."""
+        y, x, pre_end = _make_data_k10_dense()
+        samples = _run_sampler_with_horseshoe(y, x, pre_end, niter=200)
+
+        kappa = np.array(samples.kappa_shrinkage)
+        assert kappa.shape == (200, 10)
+
+    def test_horseshoe_very_small_sigma2_obs_no_nan(self):
+        """Near-zero variance y should not produce NaN in kappa."""
+        n = 50
+        y = [10.0 + 1e-8 * i for i in range(n)]
+        x = [[float(i) for i in range(n)]]
+        samples = _run_sampler_with_horseshoe(y, x, 35, niter=50, nwarmup=25)
+
+        kappa = np.array(samples.kappa_shrinkage)
+        assert not np.any(np.isnan(kappa))
+        assert np.all(np.isfinite(kappa))
+
+    def test_horseshoe_multicollinear_covariates_no_crash(self):
+        """Perfect collinearity: x2 = x1."""
+        n = 50
+        rng = np.random.default_rng(42)
+        x1 = rng.normal(5, 1, n)
+        y = (2.0 * x1 + rng.normal(0, 0.3, n)).tolist()
+        x = [x1.tolist(), x1.tolist()]  # perfect collinearity
+        samples = _run_sampler_with_horseshoe(y, x, 35, niter=50, nwarmup=25)
+
+        kappa = np.array(samples.kappa_shrinkage)
+        assert not np.any(np.isnan(kappa))
+
+
+# ---------------------------------------------------------------------------
+# Class 7: Validation
+# ---------------------------------------------------------------------------
+
+
+class TestHorseshoeValidation:
+    """Input validation for horseshoe prior."""
+
+    def test_model_options_invalid_prior_type_raises_value_error(self):
+        with pytest.raises(ValueError, match="prior_type"):
+            ModelOptions(prior_type="lasso")
+
+    def test_model_options_prior_type_empty_string_raises(self):
+        with pytest.raises(ValueError, match="prior_type"):
+            ModelOptions(prior_type="")
+
+    def test_model_options_prior_type_spike_slab_is_valid(self):
+        opts = ModelOptions(prior_type="spike_slab")
+        assert opts.prior_type == "spike_slab"
+
+    def test_model_options_prior_type_horseshoe_is_valid(self):
+        opts = ModelOptions(prior_type="horseshoe")
+        assert opts.prior_type == "horseshoe"
+
+    def test_model_options_prior_type_default_is_spike_slab(self):
+        opts = ModelOptions()
+        assert opts.prior_type == "spike_slab"
+
+    def test_horseshoe_with_dynamic_regression_raises_value_error(self):
+        y = [10.0 + 0.1 * i for i in range(20)]
+        x = [[float(i) for i in range(20)]]
+        with pytest.raises(ValueError, match="dynamic_regression"):
+            run_gibbs_sampler(
+                y=y,
+                x=x,
+                pre_end=15,
+                niter=10,
+                nwarmup=5,
+                nchains=1,
+                seed=42,
+                prior_level_sd=0.01,
+                expected_model_size=1.0,
+                dynamic_regression=True,
+                prior_type="horseshoe",
+            )
+
+    def test_model_options_horseshoe_with_dynamic_regression_raises(self):
+        with pytest.raises(ValueError, match="dynamic_regression"):
+            ModelOptions(prior_type="horseshoe", dynamic_regression=True)
+
+    def test_horseshoe_with_retrospective_mode_raises_value_error(self):
+        rng = np.random.default_rng(42)
+        n = 80
+        dates = pd.date_range("2020-01-01", periods=n, freq="D")
+        x = rng.normal(5, 1, n)
+        y = 1.0 * x + rng.normal(0, 0.5, n)
+        y[56:] += 3.0
+        df = pd.DataFrame({"y": y, "x1": x}, index=dates)
+        pre = ["2020-01-01", "2020-02-25"]
+        post = ["2020-02-26", "2020-03-20"]
+        with pytest.raises(ValueError, match="retrospective"):
+            CausalImpact(
+                df,
+                pre,
+                post,
+                model_args={
+                    "niter": 100,
+                    "nwarmup": 50,
+                    "seed": 1,
+                    "prior_type": "horseshoe",
+                    "mode": "retrospective",
+                },
+            )
+
+    def test_horseshoe_nan_in_pre_period_raises_error(self):
+        y = [10.0, 11.0, float("nan"), 13.0, 14.0, 15.0, 16.0, 17.0]
+        x = [[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]]
+        with pytest.raises(ValueError, match="NaN"):
+            _run_sampler_with_horseshoe(y, x, 5, niter=10, nwarmup=5)
+
+
+# ---------------------------------------------------------------------------
+# Class 8: Python API integration
+# ---------------------------------------------------------------------------
+
+
+def _make_test_data_with_effect():
+    """DataFrame with 1 covariate and a true effect of 3.0."""
+    rng = np.random.default_rng(42)
+    n = 80
+    dates = pd.date_range("2020-01-01", periods=n, freq="D")
+    x = rng.normal(5, 1, n)
+    y = 1.0 * x + rng.normal(0, 0.5, n)
+    y[56:] += 3.0
+    df = pd.DataFrame({"y": y, "x1": x}, index=dates)
+    pre = ["2020-01-01", "2020-02-25"]
+    post = ["2020-02-26", "2020-03-20"]
+    return df, pre, post
+
+
+class TestHorseshoePythonAPI:
+    """End-to-end tests via CausalImpact class."""
+
+    def test_causal_impact_horseshoe_end_to_end_summary_not_none(self):
+        df, pre, post = _make_test_data_with_effect()
+        ci = CausalImpact(
+            df,
+            pre,
+            post,
+            model_args={
+                "prior_type": "horseshoe",
+                "niter": 200,
+                "nwarmup": 100,
+                "seed": 42,
+            },
+        )
+
+        assert ci.summary() is not None
+
+    def test_causal_impact_horseshoe_posterior_shrinkage_shape_matches_covariates(
+        self,
+    ):
+        df, pre, post = _make_test_data_with_effect()
+        ci = CausalImpact(
+            df,
+            pre,
+            post,
+            model_args={
+                "prior_type": "horseshoe",
+                "niter": 200,
+                "nwarmup": 100,
+                "seed": 42,
+            },
+        )
+
+        shrinkage = ci.posterior_shrinkage
+        assert shrinkage is not None
+        assert shrinkage.shape == (1,)
+
+    def test_causal_impact_horseshoe_posterior_shrinkage_in_unit_interval(self):
+        df, pre, post = _make_test_data_with_effect()
+        ci = CausalImpact(
+            df,
+            pre,
+            post,
+            model_args={
+                "prior_type": "horseshoe",
+                "niter": 200,
+                "nwarmup": 100,
+                "seed": 42,
+            },
+        )
+
+        shrinkage = ci.posterior_shrinkage
+        assert np.all(shrinkage >= 0)
+        assert np.all(shrinkage <= 1)
+
+    def test_causal_impact_horseshoe_pip_is_none(self):
+        """posterior_inclusion_probs should be None for horseshoe."""
+        df, pre, post = _make_test_data_with_effect()
+        ci = CausalImpact(
+            df,
+            pre,
+            post,
+            model_args={
+                "prior_type": "horseshoe",
+                "niter": 200,
+                "nwarmup": 100,
+                "seed": 42,
+            },
+        )
+
+        assert ci.posterior_inclusion_probs is None
+
+    def test_causal_impact_horseshoe_detects_positive_effect(self):
+        df, pre, post = _make_test_data_with_effect()
+        ci = CausalImpact(
+            df,
+            pre,
+            post,
+            model_args={
+                "prior_type": "horseshoe",
+                "niter": 200,
+                "nwarmup": 100,
+                "seed": 42,
+            },
+        )
+
+        assert ci.summary_stats["point_effect_mean"] > 0
+
+    def test_causal_impact_horseshoe_dict_and_model_options_produce_same_result(
+        self,
+    ):
+        df, pre, post = _make_test_data_with_effect()
+        params_dict = {
+            "niter": 200,
+            "nwarmup": 100,
+            "seed": 42,
+            "prior_type": "horseshoe",
+        }
+        params_opts = ModelOptions(
+            niter=200, nwarmup=100, seed=42, prior_type="horseshoe"
+        )
+
+        ci_dict = CausalImpact(df, pre, post, model_args=params_dict)
+        ci_opts = CausalImpact(df, pre, post, model_args=params_opts)
+
+        assert ci_dict.summary_stats["point_effect_mean"] == pytest.approx(
+            ci_opts.summary_stats["point_effect_mean"], rel=1e-10
+        )
+
+    def test_causal_impact_horseshoe_k0_posterior_shrinkage_is_none(self):
+        """No covariates + horseshoe → posterior_shrinkage is None."""
+        rng = np.random.default_rng(42)
+        n = 60
+        dates = pd.date_range("2020-01-01", periods=n, freq="D")
+        y = np.cumsum(rng.normal(0, 0.1, n)) + 10.0
+        y[42:] += 2.0
+        df = pd.DataFrame({"y": y}, index=dates)
+        pre = ["2020-01-01", "2020-02-11"]
+        post = ["2020-02-12", "2020-02-29"]
+        ci = CausalImpact(
+            df,
+            pre,
+            post,
+            model_args={
+                "prior_type": "horseshoe",
+                "niter": 100,
+                "nwarmup": 50,
+                "seed": 42,
+            },
+        )
+
+        assert ci.posterior_shrinkage is None
+
+    def test_causal_impact_spike_slab_posterior_shrinkage_is_none(self):
+        """Spike-slab prior → posterior_shrinkage is None."""
+        df, pre, post = _make_test_data_with_effect()
+        ci = CausalImpact(
+            df,
+            pre,
+            post,
+            model_args={
+                "prior_type": "spike_slab",
+                "niter": 100,
+                "nwarmup": 50,
+                "seed": 42,
+            },
+        )
+
+        assert ci.posterior_shrinkage is None
+
+
+# ---------------------------------------------------------------------------
+# Class 9: Dense DGP comparison
+# ---------------------------------------------------------------------------
+
+
+class TestHorseshoeDenseDGPComparison:
+    """Compare horseshoe vs spike_slab on dense DGP scenarios."""
+
+    def test_horseshoe_dense_dgp_mse_not_worse_than_spike_slab(self):
+        """Horseshoe MSE should not be dramatically worse on dense DGP."""
+        y, x, pre_end = _make_data_k10_dense()
+
+        samples_hs = _run_sampler_with_horseshoe(
+            y, x, pre_end, niter=500, nwarmup=250
+        )
+        samples_ss = run_gibbs_sampler(
+            y=y,
+            x=x,
+            pre_end=pre_end,
+            niter=500,
+            nwarmup=250,
+            nchains=1,
+            seed=42,
+            prior_level_sd=0.01,
+            expected_model_size=1.0,
+            prior_type="spike_slab",
+        )
+
+        y_post = np.array(y[pre_end:])
+        pred_hs = np.array(samples_hs.predictions).mean(axis=0)
+        pred_ss = np.array(samples_ss.predictions).mean(axis=0)
+        mse_hs = np.mean((y_post - pred_hs) ** 2)
+        mse_ss = np.mean((y_post - pred_ss) ** 2)
+
+        assert mse_hs <= mse_ss * 1.5
+
+    def test_horseshoe_dense_dgp_predictions_finite_and_within_3sd(self):
+        """Predictions on dense DGP (5 signal + 5 noise) should be finite and reasonable."""
+        y, x, pre_end = _make_data_k10_dense()
+        samples = _run_sampler_with_horseshoe(
+            y, x, pre_end, niter=500, nwarmup=250
+        )
+
+        pred = np.array(samples.predictions)
+        assert np.all(np.isfinite(pred))
+
+        y_post = np.array(y[pre_end:])
+        pred_mean = pred.mean(axis=0)
+        pred_sd = pred.std(axis=0)
+        # Predictions should be within 3 SD of post-period mean
+        assert np.abs(pred_mean.mean() - y_post.mean()) < 3 * pred_sd.mean()
+
+
+# ---------------------------------------------------------------------------
+# Class 10: Seasonal + horseshoe
+# ---------------------------------------------------------------------------
+
+
+class TestHorseshoeWithSeasonal:
+    """Horseshoe + seasonal state-space model."""
+
+    def test_horseshoe_with_seasonal_kappa_shape_correct(self):
+        """Seasonal + horseshoe: kappa shape = (niter, k)."""
+        rng = np.random.default_rng(42)
+        n = 100
+        x1 = rng.normal(5, 1, n)
+        x2 = rng.normal(0, 1, n)
+        y = 2.0 * x1 + rng.normal(0, 0.3, n)
+        samples = run_gibbs_sampler(
+            y=y.tolist(),
+            x=[x1.tolist(), x2.tolist()],
+            pre_end=70,
+            niter=200,
+            nwarmup=100,
+            nchains=1,
+            seed=42,
+            prior_level_sd=0.01,
+            expected_model_size=1.0,
+            nseasons=7.0,
+            season_duration=1.0,
+            prior_type="horseshoe",
+        )
+
+        kappa = np.array(samples.kappa_shrinkage)
+        assert kappa.shape == (200, 2)
+
+    def test_horseshoe_with_seasonal_no_nan_in_predictions(self):
+        """Seasonal + horseshoe: all predictions are finite."""
+        rng = np.random.default_rng(42)
+        n = 100
+        x1 = rng.normal(5, 1, n)
+        y = 2.0 * x1 + rng.normal(0, 0.3, n)
+        samples = run_gibbs_sampler(
+            y=y.tolist(),
+            x=[x1.tolist()],
+            pre_end=70,
+            niter=200,
+            nwarmup=100,
+            nchains=1,
+            seed=42,
+            prior_level_sd=0.01,
+            expected_model_size=1.0,
+            nseasons=7.0,
+            season_duration=1.0,
+            prior_type="horseshoe",
+        )
+
+        pred = np.array(samples.predictions)
+        assert np.all(np.isfinite(pred))

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -381,3 +381,7 @@ class TestDictValidation:
         df, pre, post = _make_test_data()
         with pytest.raises(ValueError, match="nseasons must be provided"):
             CausalImpact(df, pre, post, model_args={"season_duration": 1})
+
+    def test_model_options_rejects_mode_kwarg(self) -> None:
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            ModelOptions(mode="retrospective")  # type: ignore[call-arg]

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -350,7 +350,7 @@ class TestBackwardCompatibility:
 
 
 class TestDictValidation:
-    """dict 経路でも ModelOptions.__post_init__ と同等の動的バリデーションが行われることを確認する。"""
+    """dict path runs ModelOptions.__post_init__ validation."""
 
     @pytest.mark.parametrize(
         ("key", "bad_value", "match"),

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -232,6 +232,7 @@ class TestToDict:
             "expected_model_size",
             "dynamic_regression",
             "state_model",
+            "prior_type",
             "nseasons",
             "season_duration",
         }
@@ -261,6 +262,38 @@ def _make_test_data():
     pre = ["2020-01-01", "2020-02-25"]
     post = ["2020-02-26", "2020-03-20"]
     return df, pre, post
+
+
+# ---------------------------------------------------------------------------
+# Boundary: prior_type
+# ---------------------------------------------------------------------------
+
+
+class TestPriorTypeBoundary:
+    def test_prior_type_default_is_spike_slab(self):
+        opts = ModelOptions()
+        assert opts.prior_type == "spike_slab"
+
+    def test_prior_type_horseshoe_is_valid(self):
+        opts = ModelOptions(prior_type="horseshoe")
+        assert opts.prior_type == "horseshoe"
+
+    def test_prior_type_spike_slab_is_valid(self):
+        opts = ModelOptions(prior_type="spike_slab")
+        assert opts.prior_type == "spike_slab"
+
+    def test_prior_type_invalid_raises(self):
+        with pytest.raises(ValueError, match="prior_type"):
+            ModelOptions(prior_type="ridge")
+
+    def test_prior_type_in_to_dict(self):
+        d = ModelOptions().to_dict()
+        assert "prior_type" in d
+        assert d["prior_type"] == "spike_slab"
+
+    def test_horseshoe_with_dynamic_regression_raises(self):
+        with pytest.raises(ValueError):
+            ModelOptions(prior_type="horseshoe", dynamic_regression=True)
 
 
 class TestBackwardCompatibility:
@@ -314,3 +347,37 @@ class TestBackwardCompatibility:
             },
         )
         assert ci.summary() is not None
+
+
+class TestDictValidation:
+    """dict 経路でも ModelOptions.__post_init__ と同等の動的バリデーションが行われることを確認する。"""
+
+    @pytest.mark.parametrize(
+        ("key", "bad_value", "match"),
+        [
+            ("niter", 0, "niter must be >= 1"),
+            ("nwarmup", -1, "nwarmup must be >= 0"),
+            ("nchains", 0, "nchains must be >= 1"),
+            ("prior_level_sd", 0.0, "prior_level_sd must be > 0"),
+            ("expected_model_size", 0, "expected_model_size must be > 0"),
+            ("state_model", "bad", "state_model must be one of"),
+            ("prior_type", "bad", "prior_type must be"),
+            ("dynamic_regression", "yes", "dynamic_regression must be a bool"),
+        ],
+    )
+    def test_invalid_dict_raises(self, key: str, bad_value: object, match: str) -> None:
+        df, pre, post = _make_test_data()
+        with pytest.raises(ValueError, match=match):
+            CausalImpact(df, pre, post, model_args={key: bad_value})
+
+    def test_dict_nseasons_without_value_raises(self) -> None:
+        df, pre, post = _make_test_data()
+        with pytest.raises(ValueError, match="season_duration must be"):
+            CausalImpact(
+                df, pre, post, model_args={"nseasons": 7, "season_duration": 0}
+            )
+
+    def test_dict_season_duration_without_nseasons_raises(self) -> None:
+        df, pre, post = _make_test_data()
+        with pytest.raises(ValueError, match="nseasons must be provided"):
+            CausalImpact(df, pre, post, model_args={"season_duration": 1})

--- a/tests/test_rust_sampler.py
+++ b/tests/test_rust_sampler.py
@@ -414,6 +414,27 @@ class TestSamplerKappaShrinkage:
         assert result.kappa_shrinkage == []
 
 
+class TestSamplerCovariateValidation:
+    """Covariate shape validation at PyO3 boundary."""
+
+    def test_sampler_rejects_covariate_length_mismatch(self):
+        y = [1.0, 2.0, 3.0, 4.0, 5.0]
+        x_wrong = [[0.1, 0.2, 0.3]]  # length 3, y length 5
+        with pytest.raises(
+            ValueError, match="covariate column 0 has length 3 but y has length 5"
+        ):
+            run_gibbs_sampler(
+                y=y,
+                x=x_wrong,
+                pre_end=3,
+                niter=5,
+                nwarmup=0,
+                nchains=1,
+                seed=42,
+                prior_level_sd=0.01,
+            )
+
+
 class TestSamplerConvergence:
     """Estimation accuracy on known signals."""
 

--- a/tests/test_rust_sampler.py
+++ b/tests/test_rust_sampler.py
@@ -357,6 +357,63 @@ class TestSamplerErrors:
             )
 
 
+class TestSamplerKappaShrinkage:
+    """kappa_shrinkage field tests for horseshoe/spike-slab."""
+
+    def test_sampler_horseshoe_returns_kappa_shrinkage_field(self):
+        """R1: horseshoe returns kappa_shrinkage with correct length."""
+        y = [10.0 + 0.1 * i for i in range(50)]
+        x1 = [0.5 * i for i in range(50)]
+        x2 = [0.3 * i for i in range(50)]
+        result = run_gibbs_sampler(
+            y=y,
+            x=[x1, x2],
+            pre_end=35,
+            niter=50,
+            nwarmup=10,
+            nchains=1,
+            seed=42,
+            prior_level_sd=0.01,
+            prior_type="horseshoe",
+        )
+        assert hasattr(result, "kappa_shrinkage")
+        assert len(result.kappa_shrinkage) == 50
+        assert len(result.kappa_shrinkage[0]) == 2
+
+    def test_sampler_spike_slab_kappa_shrinkage_is_empty_list(self):
+        """R2: spike_slab (default) returns empty kappa_shrinkage."""
+        y = [10.0 + 0.1 * i for i in range(50)]
+        x1 = [0.5 * i for i in range(50)]
+        x2 = [0.3 * i for i in range(50)]
+        result = run_gibbs_sampler(
+            y=y,
+            x=[x1, x2],
+            pre_end=35,
+            niter=50,
+            nwarmup=10,
+            nchains=1,
+            seed=42,
+            prior_level_sd=0.01,
+        )
+        assert result.kappa_shrinkage == []
+
+    def test_sampler_no_covariates_horseshoe_kappa_is_empty(self):
+        """R3: k=0 with horseshoe returns empty kappa_shrinkage."""
+        y = [10.0 + 0.1 * i for i in range(50)]
+        result = run_gibbs_sampler(
+            y=y,
+            x=None,
+            pre_end=35,
+            niter=50,
+            nwarmup=10,
+            nchains=1,
+            seed=42,
+            prior_level_sd=0.01,
+            prior_type="horseshoe",
+        )
+        assert result.kappa_shrinkage == []
+
+
 class TestSamplerConvergence:
     """Estimation accuracy on known signals."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "bsts-causalimpact"
-version = "1.5.1"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
## Summary

Horseshoe prior (Carvalho, Polson & Scott 2010) を spike-and-slab の代替として BSTS 回帰に追加。
Dense DGP（多くの共変量が真の効果を持つケース）で spike-and-slab より優位な連続的 shrinkage を提供する。

- `ModelOptions(prior_type='horseshoe')` で有効化
- Makalic & Schmidt (2015) auxiliary variable augmentation による効率的 Gibbs sampling
- `posterior_shrinkage` プロパティ: 共変量ごとの平均 shrinkage factor κ_j = E[1/(1+λ_j²τ²)]
- `posterior_inclusion_probs` は horseshoe 時 `None`（spike-slab 専用を維持）

### Rust (sampler.rs, lib.rs, distributions.rs)

- `PriorType` enum（SpikeSlab/Horseshoe）で型安全な分岐
- `HorseshoeState` 構造体: τ², ξ, λ²_j, ν_j の管理 + `kappa()` 診断
- `sample_horseshoe()`: seasonal / non-seasonal 両パスに対応
- `sample_inv_gamma` の non-finite parameter guard（extreme-scale 入力での panic 防止）
- `kappa()` と precision diagonal の floor を `1e-30` に統一

### Python (options.py, main.py)

- `ModelOptions.prior_type` フィールド + バリデーション
- `_normalize_model_args()`: unknown dict key rejection（typo の黙殺を防止）
- `posterior_shrinkage` プロパティ（horseshoe 専用）
- horseshoe + dynamic_regression/retrospective → ValueError

### Tests (56 new tests)

- `test_horseshoe.py`: 10 classes, 47 tests（shape, shrinkage behavior, numerical stability, Python API, dense DGP, seasonal）
- `test_options.py`: +6 tests（TestPriorTypeBoundary）
- `test_rust_sampler.py`: +3 tests（TestSamplerKappaShrinkage）

### Docs

- `docs/api.md`: usage, shrinkage diagnostics table, incompatible combinations
- `docs/theory.md`: hierarchical model, conditional posteriors, when-to-use guide
- `README.md`: feature tables updated
- `CHANGELOG.md`: feat + fix entries

## References

- Kohns, D. & Bhattacharjee, A. (2022). arXiv:2011.00938
- Makalic, E. & Schmidt, D.F. (2015). IEEE SPL 23(1), 179-182
- Carvalho, C.M., Polson, N.G. & Scott, J.G. (2010). Biometrika 97(2), 465-480

## Test plan

- [x] `cargo test` — 150 passed
- [x] `.venv/bin/pytest tests/ -v` — 443 passed, 12 skipped, 1 xfailed
- [x] Codex CLI review — Critical/Warning issues resolved
- [x] Architect review — B+ (High issue resolved: Gibbs order comment)
- [x] Unit-test-designer review — 4/5 (test name fix applied)